### PR TITLE
Recommend removing SSH private key to prevent accidentlly commiting it…

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,16 +514,20 @@ The benefits of a public repository include:
         secretRef:
           name: github-deploy-key
       ```
-  7. Commit and push changes
-  8. Force flux to reconcile your changes
+  7. Remove the files `cluster/github-deploy-key` and `cluster\github-deploy-key.pub` to prevent the private key from being pushed to your repository.
+      ```sh
+      rm ./cluster/github-deploy-key*
+      ```
+  8. Commit and push changes
+  9. Force flux to reconcile your changes
      ```sh
      task cluster:reconcile
      ```
-  9. Verify git repository is now using SSH:
+  10. Verify git repository is now using SSH:
       ```sh
       task cluster:gitrepositories
       ```
-  10. Optionally set your repository to Private in your repository settings.
+  11. Optionally set your repository to Private in your repository settings.
 </details>
 
 ## 👉 Troubleshooting


### PR DESCRIPTION
… to version control.

**Description of the change**

Added a step to the "Authenticate Flux over SSH" section. This additional step is to remove the private key from the local file structure before committing to VCS so as to prevent accidentally pushing the private key.

**Benefits**

This will decrease the likely hood of someone's keys leaking on Github.

**Possible drawbacks**

In the case of repository loss, the process may need to be repeated in it's entirety.
