### PR TITLE
workaround for ansible galaxy role

### DIFF
--- a/provision/ansible/requirements.yml
+++ b/provision/ansible/requirements.yml
@@ -9,5 +9,6 @@ collections:
   - name: ansible.utils
     version: 2.6.1
 roles:
-  - src: xanmanning.k3s
+  - name: xanmanning.k3s
+    src: https://github.com/PyratLabs/ansible-role-k3s.git
     version: v3.3.0


### PR DESCRIPTION
at the moment v3.3.0 of  `xanmanning.k3s` seems to be unavailable  see more details here: https://github.com/PyratLabs/ansible-role-k3s/issues/196 as such I would suggest considering this workaround. if/when that issue is resolved, this can be reversed.

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
