### PR TITLE
fix(metallb): Update to version with CRDs

### DIFF
--- a/cluster/apps/networking/metallb/config.yaml
+++ b/cluster/apps/networking/metallb/config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-ip
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - default-pool
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - "${METALLB_LB_RANGE}"

--- a/cluster/apps/networking/metallb/helm-release.yaml
+++ b/cluster/apps/networking/metallb/helm-release.yaml
@@ -26,4 +26,3 @@ spec:
       create: false
     crds:
       enabled: false
-

--- a/cluster/apps/networking/metallb/helm-release.yaml
+++ b/cluster/apps/networking/metallb/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: metallb
-      version: 0.12.1
+      version: 0.13.5
       sourceRef:
         kind: HelmRepository
         name: metallb
@@ -24,9 +24,6 @@ spec:
   values:
     psp:
       create: false
-    configInline:
-      address-pools:
-        - name: default
-          protocol: layer2
-          addresses:
-            - "${METALLB_LB_RANGE}"
+    crds:
+      enabled: false
+

--- a/cluster/apps/networking/metallb/kustomization.yaml
+++ b/cluster/apps/networking/metallb/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - config.yaml

--- a/cluster/crds/kustomization.yaml
+++ b/cluster/crds/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - cert-manager
   - system-upgrade-controller
+  - metallb

--- a/cluster/crds/metallb/crds.yaml
+++ b/cluster/crds/metallb/crds.yaml
@@ -28,25 +28,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: metallb-source
-  healthChecks:
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: addresspools.metallb.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: bfdprofiles.metallb.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: bgpadvertisements.metallb.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: bgppeers.metallb.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: communities.metallb.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: ipaddresspools.metallb.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: l2advertisements.metallb.io

--- a/cluster/crds/metallb/crds.yaml
+++ b/cluster/crds/metallb/crds.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: metallb-source
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://github.com/metallb/metallb.git
+  ref:
+    # renovate: registryUrl=https://metallb.github.io/metallb chart=metallb
+    tag: v0.13.5
+  ignore: |
+    # exclude all
+    /*
+    # include crd directory
+    !/config/crd
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: crds-metallb
+  namespace: flux-system
+spec:
+  interval: 30m
+  prune: false
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: metallb-source
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: addresspools.metallb.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: bfdprofiles.metallb.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: bgpadvertisements.metallb.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: bgppeers.metallb.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: communities.metallb.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: ipaddresspools.metallb.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: l2advertisements.metallb.io

--- a/cluster/crds/metallb/kustomization.yaml
+++ b/cluster/crds/metallb/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - crds.yaml

--- a/cluster/crds/metallb/kustomization.yaml
+++ b/cluster/crds/metallb/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
**Description of the change**

Adds CRDs for metlalb
Adds a config file for metallb that creases the address pool off of the same variable it was created from before.
Updates metallb to latest v0.13.5


**Benefits**

Allows updating to the latest version without any drastic changes

**Possible drawbacks**

Adds a crd - Can't confirm I did it perfectly, can only confirm that it works in this configuration without any issue.
Code blatantly stolen from [Belak](https://github.com/belak/homelab-infra/blob/ebe71636a1a16b32667b09a6337eff24b554ee3e/cluster/bootstrap/crds/metallb-crds.yaml)

**Applicable issues**

- Fixes #409
- Fixes #394 

**Additional information**