### PR TITLE
cluster-prepare.yml include group_vars & cloudflare-api-key secret namespace

### DIFF
--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -27,6 +27,9 @@
               127.0.1.1   {{ inventory_hostname }}
     - name: Packages
       block:
+        - name: Packages | Include package variables
+          ansible.builtin.include_vars:
+            dir: ../inventory/group_vars/kubernetes
         - name: Packages | Improve dnf performance
           ansible.builtin.blockinfile:
             path: /etc/dnf/dnf.conf

--- a/tmpl/cluster/cert-manager-secret.sops.yaml
+++ b/tmpl/cluster/cert-manager-secret.sops.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudflare-api-key
-  namespace: kube-system
+  namespace: networking
 stringData:
     api-key: ${BOOTSTRAP_CLOUDFLARE_APIKEY}


### PR DESCRIPTION
**Description of the change**

The `Packages | Install required packages` task was failing because the `provision/ansible/inventory/group_vars/kubernetes/os.yml` was not being included in the execution of the playbook
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

The playbook will not error out.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None that I know of.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Discussed in  #499 as a side topic

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
