### PR TITLE
Update cluster-prepare to include group_vars

### DIFF
--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -27,6 +27,9 @@
               127.0.1.1   {{ inventory_hostname }}
     - name: Packages
       block:
+         - name: Packages | Include package variables
+          ansible.builtin.include_vars:
+            dir: ../inventory/group_vars/kubernetes
         - name: Packages | Improve dnf performance
           ansible.builtin.blockinfile:
             path: /etc/dnf/dnf.conf

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -27,7 +27,7 @@
               127.0.1.1   {{ inventory_hostname }}
     - name: Packages
       block:
-         - name: Packages | Include package variables
+        - name: Packages | Include package variables
           ansible.builtin.include_vars:
             dir: ../inventory/group_vars/kubernetes
         - name: Packages | Improve dnf performance


### PR DESCRIPTION
**Description of the change**

 Added include_vars task which I found as the fix to force the `Packages | Remove leaf packages` task to read `group_vars/kubernetes/os.yml` for its list of packages to install.

**Benefits**

Allows playbook to complete successfully

**Possible drawbacks**

There might be a better way

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Discussed in (#499) but no formal issue opened

**Additional information**

Sorry for closing the previous PR, I wanted to get this on a clean branch
