### PR TITLE
Update Hajimari HR and Bookmarks syntax

### DIFF
--- a/cluster/apps/default/hajimari/helm-release.yaml
+++ b/cluster/apps/default/hajimari/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: hajimari
-      version: 1.2.0
+      version: 2.0.2
       sourceRef:
         kind: HelmRepository
         name: hajimari
@@ -34,65 +34,66 @@ spec:
         - name: Some External Cluster Service
           url: http://192.168.1.100:5000
           icon: test-tube
-      groups:
-        - name: Communicate
-          links:
+      showGlobalBookmarks: true
+      globalBookmarks:
+        - group: Communicate
+          bookmarks:
             - name: Discord
               url: "https://discord.com"
             - name: Gmail
               url: "https://gmail.com"
             - name: Slack
               url: "https://slack.com/signin"
-        - name: Cloud
-          links:
+        - group: Cloud
+          bookmarks:
             - name: Box
               url: "https://box.com"
             - name: Dropbox
               url: "https://dropbox.com"
             - name: Drive
               url: "https://drive.google.com"
-        - name: Design
-          links:
+        - group: Design
+          bookmarks:
             - name: Awwwards
               url: "https://awwwards.com"
             - name: Dribbble
               url: "https://dribbble.com"
             - name: Muz.li
               url: "https://medium.muz.li/"
-        - name: Dev
-          links:
+        - group: Dev
+          bookmarks:
             - name: Codepen
               url: "https://codepen.io/"
             - name: Devdocs
               url: "https://devdocs.io"
             - name: Devhints
               url: "https://devhints.io"
-        - name: Lifestyle
-          links:
+        - group: Lifestyle
+          bookmarks:
             - name: Design Milk
               url: "https://design-milk.com/category/interior-design/"
             - name: Dwell
               url: "https://www.dwell.com/"
             - name: Freshome
               url: "https://www.mymove.com/freshome/"
-        - name: Media
-          links:
+        - group: Media
+          bookmarks:
             - name: Spotify
               url: "http://browse.spotify.com"
             - name: Trakt
               url: "http://trakt.tv"
             - name: YouTube
               url: "https://youtube.com/feed/subscriptions"
-        - name: Reading
-          links:
+        - group: Reading
+          bookmarks:
             - name: Instapaper
               url: "https://www.instapaper.com/u"
             - name: Medium
               url: "http://medium.com"
             - name: Reddit
               url: "http://reddit.com"
-        - name: Tech
-          links:
+        - group: Tech
+          bookmarks:
             - name: Hacker News
               url: "https://news.ycombinator.com/"
             - name: The Verge


### PR DESCRIPTION
**Description of the change**

Hajimari has moved to Helm Release v2.0.2 which contains API updates required for clusters running k8s >1.22.

The Hajimari dev also updated the syntax needed to display bookmarks in groups

**Benefits**

Hajimari will deploy successfully

**Possible drawbacks**

None that I know of.

