### PR TITLE
Update receiver.yaml to match repo structure

### DIFF
--- a/tmpl/cluster/flux-system/webhooks/github/receiver.yaml
+++ b/tmpl/cluster/flux-system/webhooks/github/receiver.yaml
@@ -16,22 +16,18 @@ spec:
       kind: GitRepository
       name: flux-cluster
       namespace: flux-system
-
     - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
       kind: Kustomization
       name: apps
       namespace: flux-system
-
     - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
       kind: Kustomization
-      name: core
+      name: charts
       namespace: flux-system
-
     - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
       kind: Kustomization
-      name: crds
+      name: config
       namespace: flux-system
-
     - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
       kind: Kustomization
       name: flux-cluster


### PR DESCRIPTION


**Description of the change**

It appears the template used to have a different structure that contained a crds and core folder. this broke the Github Webhook Receiver because the directories did not exists.

**Benefits**

Webhook Receiver works out of the box

**Possible drawbacks**

None

**Applicable issues**

None, discussed in Discord

**Additional information**

None
