### PR TITLE
Modify bootstrap kustomization to match flux-install fluxtomization

### DIFF
--- a/cluster/bootstrap/kustomization.yaml
+++ b/cluster/bootstrap/kustomization.yaml
@@ -3,3 +3,27 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - github.com/fluxcd/flux2/manifests/install?ref=v0.36.0
+images:
+  - name: fluxcd/helm-controller
+    newName: ghcr.io/fluxcd/helm-controller
+  - name: fluxcd/image-automation-controller
+    newName: ghcr.io/fluxcd/image-automation-controller
+  - name: fluxcd/image-reflector-controller
+    newName: ghcr.io/fluxcd/image-reflector-controller
+  - name: fluxcd/kustomize-controller
+    newName: ghcr.io/fluxcd/kustomize-controller
+  - name: fluxcd/notification-controller
+    newName: ghcr.io/fluxcd/notification-controller
+  - name: fluxcd/source-controller
+    newName: ghcr.io/fluxcd/source-controller
+patches:
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: NetworkPolicy
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: not-used


### PR DESCRIPTION
**Description of the change**

Matches the bootstrap flux install to the final flux-installation fluxtomization

**Benefits**

Only the ghcr images will be pulled

**Possible drawbacks**

Somebody might like docker.io

**Applicable issues**

N/A


**Additional information**

N/A
