### PR TITLE
Ansible support to multiple distros

### DIFF
--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -25,7 +25,7 @@
             path: /etc/hosts
             block: |
               127.0.1.1   {{ inventory_hostname }}
-    - name: Packages
+    - name: Packages | Fedora
       block:
         - name: Packages | Improve dnf performance
           ansible.builtin.blockinfile:
@@ -55,6 +55,16 @@
             service: dnf-automatic-download.timer
             enabled: true
             state: started
+      when: ansible_facts['distribution'] == 'Fedora'
+    - name: Packages | Ubuntu
+      block:
+        - name: Packages | Ensure the cache is updated
+          ansible.builtin.apt:
+            update_cache: yes
+        - name: Packages | Ensure the packages are updated
+          ansible.builtin.apt:
+            upgrade: dist
+      when: ansible_facts['distribution'] == 'Ubuntu'
     - name: User Configuration
       block:
         - name: User Configuration | Add additional SSH public keys


### PR DESCRIPTION
See #389

I have two main goals, let me know your thoughts:

1. Most importantly, I'd like the playbooks to not fail in case we're running anything else than Fedora. For that we can make usage of `ansible_facts['distribution']` as previously discussed.
2. Optionally, this template can provide support and maintain tasks for Ubuntu. I'm totally fine if you're not in favor it.