### PR TITLE
Add Support back for Ubuntu as OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ _Additional applications include [hajimari](https://github.com/toboshii/hajimari
 For provisioning the following tools will be used:
 
 - [Fedora 36 Server](https://getfedora.org/en/server/download/) - Universal operating system that supports running all kinds of home related workloads in Kubernetes and has a faster release cycle
+- [Ubuntu 22.04 Server](https://ubuntu.com/download/server) - Alternative operating system, limited community support
 - [Ansible](https://www.ansible.com) - Provision Fedora Server and install k3s
 - [Terraform](https://www.terraform.io) - Provision an already existing Cloudflare domain and certain DNS records to be used with your k3s cluster
 

--- a/provision/ansible/inventory/group_vars/kubernetes/os.yml
+++ b/provision/ansible/inventory/group_vars/kubernetes/os.yml
@@ -5,15 +5,29 @@
 # (list) Additional ssh public keys to add to the nodes
 # ssh_authorized_keys:
 
-packages:
-  - dnf-plugin-system-upgrade
-  - dnf-utils
-  - hdparm
-  - htop
-  - intel-gpu-tools
-  - ipvsadm
-  - lm_sensors
-  - nano
-  - nvme-cli
-  - socat
-  - python3-libselinux
+fedora:
+  packages:
+    - dnf-plugin-system-upgrade
+    - dnf-utils
+    - hdparm
+    - htop
+    - intel-gpu-tools
+    - ipvsadm
+    - lm_sensors
+    - nano
+    - nvme-cli
+    - socat
+    - python3-libselinux
+
+ubuntu:
+  # disable_ufw: true
+  # disable_swap: true
+  packages:
+    - hdparm
+    - htop
+    - intel-gpu-tools
+    - ipvsadm
+    - lm-sensors
+    - nano
+    - nvme-cli
+    - socat

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -25,7 +25,7 @@
             path: /etc/hosts
             block: |
               127.0.1.1   {{ inventory_hostname }}
-    - name: Packages
+    - name: Packages | Fedora
       block:
         - name: Packages | Install required packages
           ansible.builtin.dnf:
@@ -35,6 +35,16 @@
         - name: Packages | Remove leaf packages
           ansible.builtin.dnf:
             autoremove: true
+      when: ansible_facts['distribution'] == 'Fedora'
+    - name: Packages | Ubuntu
+      block:
+        - name: Packages | Ensure the cache is updated
+          ansible.builtin.apt:
+            update_cache: yes
+        - name: Packages | Ensure the packages are updated
+          ansible.builtin.apt:
+            upgrade: dist
+      when: ansible_facts['distribution'] == 'Ubuntu'
     - name: User Configuration
       block:
         - name: User Configuration | Add additional SSH public keys

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -69,7 +69,9 @@
             enabled: false
             masked: true
             state: stopped
-          when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_ufw | default true }}" == true
+          when:
+            - ansible_facts['distribution'] == 'Ubuntu'
+            - "{{ ubuntu.disable_ufw | default true }}" == true
         - name: System Configuration (1) | Enable fstrim
           ansible.builtin.systemd:
             service: fstrim.timer

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -29,7 +29,7 @@
       block:
         - name: Packages | Install required packages
           ansible.builtin.dnf:
-            name: "{{ packages | default([]) }}"
+            name: "{{ fedora.packages | default([]) }}"
             state: present
             update_cache: true
         - name: Packages | Remove leaf packages
@@ -38,12 +38,14 @@
       when: ansible_facts['distribution'] == 'Fedora'
     - name: Packages | Ubuntu
       block:
-        - name: Packages | Ensure the cache is updated
+        - name: Packages | Install required packages
           ansible.builtin.apt:
-            update_cache: yes
-        - name: Packages | Ensure the packages are updated
+            name: "{{ ubuntu.packages | default([]) }}"
+            state: present
+            update_cache: true
+        - name: Packages | Remove leaf packages
           ansible.builtin.apt:
-            upgrade: dist
+            autoremove: true
       when: ansible_facts['distribution'] == 'Ubuntu'
     - name: User Configuration
       block:
@@ -54,12 +56,20 @@
           loop: "{{ public_ssh_keys | default([]) }}"
     - name: System Configuration (1)
       block:
-        - name: System Configuration (1) | Disable firewalld
+        - name: System Configuration (1) | Disable firewalld | Fedora
           ansible.builtin.systemd:
             service: firewalld.service
             enabled: false
             masked: true
             state: stopped
+          when: ansible_facts['distribution'] == 'Fedora'
+        - name: System Configuration (1) | Disable ufw | Ubuntu
+          ansible.builtin.systemd:
+            service: ufw.service
+            enabled: false
+            masked: true
+            state: stopped
+          when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_ufw | default true }}" == true
         - name: System Configuration (1) | Enable fstrim
           ansible.builtin.systemd:
             service: fstrim.timer
@@ -95,14 +105,28 @@
               net.bridge.bridge-nf-call-ip6tables: 1
               fs.inotify.max_user_watches: 524288
               fs.inotify.max_user_instances: 512
-        - name: System Configuration (2) | Disable swap
+        - name: System Configuration (2) | Disable swap | Fedora
           ansible.builtin.dnf:
             name: zram-generator-defaults
             state: absent
-        - name: System Configuration (2) | Permissive SELinux
+          when: ansible_facts['distribution'] == 'Fedora'
+        - name: System Configuration (2) | Disable swap at runtime | Ubuntu
+          ansible.builtin.command: swapoff -a
+          when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_swap | default true }}" == true and ansible_swaptotal_mb > 0
+        - name: System Configuration (2) | Disable swap at boot | Ubuntu
+          ansible.posix.mount:
+            name: "{{ item }}"
+            fstype: swap
+            state: absent
+            loop:
+              - swap
+              - none
+          when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_swap | default true }}" == true
+        - name: System Configuration (2) | Permissive SELinux | Fedora
           ansible.posix.selinux:
             state: permissive
             policy: targeted
+          when: ansible_facts['distribution'] == 'Fedora'
       notify: Reboot
 
   handlers:

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -118,9 +118,7 @@
             name: "{{ item }}"
             fstype: swap
             state: absent
-            loop:
-              - swap
-              - none
+            loop: ["none", "swap"]
           when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_swap | default true }}" == true
         - name: System Configuration (2) | Permissive SELinux | Fedora
           ansible.posix.selinux:

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -119,7 +119,9 @@
             fstype: swap
             state: absent
             loop: ["none", "swap"]
-          when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_swap | default true }}" == true
+          when:
+            - ansible_facts['distribution'] == 'Ubuntu'
+            - "{{ ubuntu.disable_swap | default true }}" == true
         - name: System Configuration (2) | Permissive SELinux | Fedora
           ansible.posix.selinux:
             state: permissive

--- a/provision/ansible/playbooks/cluster-prepare.yml
+++ b/provision/ansible/playbooks/cluster-prepare.yml
@@ -112,7 +112,10 @@
           when: ansible_facts['distribution'] == 'Fedora'
         - name: System Configuration (2) | Disable swap at runtime | Ubuntu
           ansible.builtin.command: swapoff -a
-          when: ansible_facts['distribution'] == 'Ubuntu' and "{{ ubuntu.disable_swap | default true }}" == true and ansible_swaptotal_mb > 0
+          when:
+            - ansible_facts['distribution'] == 'Ubuntu'
+            - "{{ ubuntu.disable_swap | default true }}" == true
+            - ansible_swaptotal_mb > 0
         - name: System Configuration (2) | Disable swap at boot | Ubuntu
           ansible.posix.mount:
             name: "{{ item }}"


### PR DESCRIPTION
**Description of the change**
Picking up https://github.com/onedr0p/flux-cluster-template/pull/527 and https://github.com/onedr0p/flux-cluster-template/issues/389

Adding support for Ubuntu
**Benefits**
More choice for users on the OS layer
**Possible drawbacks**
More maintenance (thus calling it out as  limited community support)

**Additional information**

I added the requested changes from https://github.com/onedr0p/flux-cluster-template/pull/527#pullrequestreview-1190466271

To do:

- [ ] Disable AppArmor (if that is a must-have)
- [ ] Test on a real machine
