### PR TITLE
ci(renovate): Enhance GHA automerge

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -1,13 +1,13 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
       "description": "Auto merge GitHub Actions",
       "matchManagers": ["github-actions"],
-      "matchDatasources": ["github-tags"],
       "automerge": true,
       "automergeType": "branch",
       "ignoreTests": true,
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch", "digest"]
     }
   ]
 }


### PR DESCRIPTION
This change allows automerging any GitHub action types. For example the way we are doing our mdbook action, that would otherwise not get automerged.