### PR TITLE
fix: Adds missing kustomize for k8s-dashboard

### DIFF
--- a/kubernetes/apps/monitoring/kubernetes-dashboard/app/rbac.yaml
+++ b/kubernetes/apps/monitoring/kubernetes-dashboard/app/rbac.yaml
@@ -1,5 +1,5 @@
 # For dashboard sign in token:
-# kubectl -n monitoring get secret kubernetes-dashboard -o jsonpath='{.data.token}'
+# kubectl -n monitoring get secret kubernetes-dashboard -o jsonpath='{.data.token}' | base64 -d
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kubernetes/apps/monitoring/kubernetes-dashboard/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kubernetes-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app
+  - ks.yaml


### PR DESCRIPTION
Hi Devin,

when I tried to deploy kubernetes-dashboard I was following your template. However the dashboard was not deployed - I found there is a missing `Kustomization` file. 

This PR also adds step `base64 -d`  to the comment for getting secret token for login to dashboard in the file `rbac.yaml`. Reason for that is that when I tried the original secret returned by k8s I wasn't able to login and had to decoded the secret as base64. After that I was able to login via the secret token. 

Let me know what do you think about these changes. 
Cheers. 