### PR TITLE
add ipvs kernel modules for kube-vip

### DIFF
--- a/ansible/playbooks/cluster-prepare.yml
+++ b/ansible/playbooks/cluster-prepare.yml
@@ -86,13 +86,13 @@
           community.general.modprobe:
             name: "{{ item }}"
             state: present
-          loop: [br_netfilter, overlay, rbd]
+          loop: [br_netfilter, ip_vs, ip_vs_rr, overlay, rbd]
         - name: System Configuration (2) | Enable kernel modules on boot
           ansible.builtin.copy:
             mode: 0644
             content: "{{ item }}"
             dest: "/etc/modules-load.d/{{ item }}.conf"
-          loop: [br_netfilter, overlay, rbd]
+          loop: [br_netfilter, ip_vs, ip_vs_rr, overlay, rbd]
         - name: System Configuration (2) | Set sysctls
           ansible.posix.sysctl:
             name: "{{ item.key }}"


### PR DESCRIPTION
if `kube-vip` cannot find ipvs kernel modules, it will crash-loop with errors (see https://github.com/kube-vip/kube-vip/issues/506)

```txt
level=error msg="ensure IPVS kernel modules are loaded"
level=fatal msg="Error starting IPVS [netlink receive: no such file or directory]"
```

This PR loads `ip_vs` and `ip_vs_rr` and enables them at boot.

Signed-off-by: ahgraber <ahgraber@ninerealmlabs.com>