### PR TITLE
Default to empty `resolv-conf` kubelet arg in agent config

### DIFF
--- a/ansible/inventory/group_vars/master/k3s.yml
+++ b/ansible/inventory/group_vars/master/k3s.yml
@@ -31,6 +31,9 @@ k3s_server:
   cluster-cidr: "10.42.0.0/16"
   # Network CIDR to use for service IPs
   service-cidr: "10.43.0.0/16"
+  kubelet-arg:
+    # Don't pull /etc/resolv.conf from host
+    - "resolv-conf="
   kube-controller-manager-arg:
     # Required to monitor kube-controller-manager with kube-prometheus-stack
     - "bind-address=0.0.0.0"

--- a/ansible/inventory/group_vars/worker/k3s.yml
+++ b/ansible/inventory/group_vars/worker/k3s.yml
@@ -8,3 +8,7 @@ k3s_control_node: false
 # (dict) k3s settings for all worker nodes
 k3s_agent:
   node-ip: "{{ ansible_host }}"
+  kubelet-arg:
+    # Don't pull /etc/resolv.conf from host
+    - "resolv-conf="
+


### PR DESCRIPTION
Figured I'd submit a diff for the changes asked about here https://discord.com/channels/673534664354430999/740607531466096640/1071641086889562132

This change sets the K3s Agent `kubelet-arg` config setting to an empty value, which prevents K3s from using the `/etc/resolv.conf` file on the host to seed the same file in pods. In my case, I wanted to avoid `search` domains from my cluster nodes' `resolv.conf` files making their way into my pods.