### PR TITLE
fix(metallb): remove psp

### DIFF
--- a/kubernetes/apps/networking/metallb/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/metallb/app/helmrelease.yaml
@@ -28,5 +28,3 @@ spec:
   values:
     crds:
       enabled: true
-    psp:
-      create: false


### PR DESCRIPTION
It was removed in chart version 0.13.7:
https://github.com/metallb/metallb/commit/85f3f0c79d3bde54509148c8f09894f016623991