### PR TITLE
Revert "Default to empty `resolv-conf` kubelet arg in agent config"

### DIFF
--- a/ansible/inventory/group_vars/master/k3s.yml
+++ b/ansible/inventory/group_vars/master/k3s.yml
@@ -31,9 +31,6 @@ k3s_server:
   cluster-cidr: "10.42.0.0/16"
   # Network CIDR to use for service IPs
   service-cidr: "10.43.0.0/16"
-  kubelet-arg:
-    # Don't pull /etc/resolv.conf from host
-    - "resolv-conf="
   kube-controller-manager-arg:
     # Required to monitor kube-controller-manager with kube-prometheus-stack
     - "bind-address=0.0.0.0"

--- a/ansible/inventory/group_vars/worker/k3s.yml
+++ b/ansible/inventory/group_vars/worker/k3s.yml
@@ -8,7 +8,3 @@ k3s_control_node: false
 # (dict) k3s settings for all worker nodes
 k3s_agent:
   node-ip: "{{ ansible_host }}"
-  kubelet-arg:
-    # Don't pull /etc/resolv.conf from host
-    - "resolv-conf="
-


### PR DESCRIPTION
Looks like there's an issue including this with coredns crashing

Reverts onedr0p/flux-cluster-template#627