### PR TITLE
fix(github-action): update permissions on actions/labeler

### DIFF
--- a/.github/workflows/meta-labeler.yaml
+++ b/.github/workflows/meta-labeler.yaml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   labeler:
     name: Labeler


### PR DESCRIPTION
Since February 2021 Pull Requests created by Dependabot/Renovabot are treated as forks, for reducing attack surface. [[1]](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)

Which causes some workflows, like labeler to fail due to lack of permissions. This PR fixes that. [[2]](https://github.com/actions/labeler/pull/50)