### PR TITLE
feat: Disable kube-proxy and enable Calico in eBPF mode

### DIFF
--- a/ansible/inventory/group_vars/kubernetes/k3s.yml
+++ b/ansible/inventory/group_vars/kubernetes/k3s.yml
@@ -55,5 +55,6 @@ k3s_server_manifests_urls:
 # (list) A flat list of templates to deploy on the primary control plane
 # /var/lib/rancher/k3s/server/manifests
 k3s_server_manifests_templates:
+  - calico-ebpf.yaml.j2
   - calico-installation.yaml.j2
   - kube-vip-daemonset.yaml.j2

--- a/ansible/inventory/group_vars/master/k3s.yml
+++ b/ansible/inventory/group_vars/master/k3s.yml
@@ -10,38 +10,25 @@ k3s_server:
   node-ip: "{{ ansible_host }}"
   tls-san:
     - "{{ kubevip_address }}"
-  # Disable Docker - this will use the default containerd CRI
-  docker: false
-  flannel-backend: "none" # This needs to be in quotes
+  https-listen-port: 6443
+  docker: false                    # Disable Docker - this will use the default containerd CRI
+  flannel-backend: "none"          # This needs to be in quotes
   disable:
-    # Disable flannel - replaced with Calico
-    - flannel
-    # Disable local-path-provisioner - installed with Flux
-    - local-storage
-    # Disable metrics-server - installed with Flux
-    - metrics-server
-    # Disable servicelb - replaced with metallb and installed with Flux
-    - servicelb
-    # Disable traefik - replaced with ingress-nginx and installed with Flux
-    - traefik
+    - flannel                      # Disable flannel - replaced with Calico
+    - local-storage                # Disable local-path-provisioner - installed with Flux
+    - metrics-server               # Disable metrics-server - installed with Flux
+    - servicelb                    # Disable servicelb - replaced with metallb and installed with Flux
+    - traefik                      # Disable traefik - replaced with ingress-nginx and installed with Flux
   disable-network-policy: true
   disable-cloud-controller: true
+  disable-kube-proxy: true         # Disable kube-proxy - replaced with Calico eBPF
   write-kubeconfig-mode: "644"
-  # Network CIDR to use for pod IPs
-  cluster-cidr: "10.42.0.0/16"
-  # Network CIDR to use for service IPs
-  service-cidr: "10.43.0.0/16"
+  cluster-cidr: "10.42.0.0/16"     # Network CIDR to use for pod IPs
+  service-cidr: "10.43.0.0/16"     # Network CIDR to use for service IPs
   kube-controller-manager-arg:
-    # Required to monitor kube-controller-manager with kube-prometheus-stack
-    - "bind-address=0.0.0.0"
-  kube-proxy-arg:
-    # Required to monitor kube-proxy with kube-prometheus-stack
-    - "metrics-bind-address=0.0.0.0"
+    - "bind-address=0.0.0.0"       # Required to monitor kube-controller-manager with kube-prometheus-stack
   kube-scheduler-arg:
-    # Required to monitor kube-scheduler with kube-prometheus-stack
-    - "bind-address=0.0.0.0"
-  # Required to monitor etcd with kube-prometheus-stack
-  etcd-expose-metrics: true
+    - "bind-address=0.0.0.0"       # Required to monitor kube-scheduler with kube-prometheus-stack
+  etcd-expose-metrics: true        # Required to monitor etcd with kube-prometheus-stack
   kube-apiserver-arg:
-    # Required for HAProxy health-checks
-    - "anonymous-auth=true"
+    - "anonymous-auth=true"        # Required for HAProxy health-checks

--- a/ansible/playbooks/templates/calico-ebpf.yaml.j2
+++ b/ansible/playbooks/templates/calico-ebpf.yaml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tigera-operator
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-services-endpoint
+  namespace: tigera-operator
+data:
+  KUBERNETES_SERVICE_HOST: "{{ k3s_registration_address }}"
+  KUBERNETES_SERVICE_PORT: "{{ k3s_server['https-listen-port'] }}"

--- a/ansible/playbooks/templates/calico-installation.yaml.j2
+++ b/ansible/playbooks/templates/calico-installation.yaml.j2
@@ -7,6 +7,8 @@ spec:
   registry: quay.io
   imagePath: calico
   calicoNetwork:
+    hostPorts: Disabled
+    linuxDataplane: BPF
     # https://projectcalico.docs.tigera.io/networking/ip-autodetection
     nodeAddressAutodetectionV4:
       cidrs:


### PR DESCRIPTION
Calico supports the eBPF dataplane in more modern distributions like Ubuntu 20.04 and Fedora and newer.

I have been running Calico in eBPF for awhile now and it's been very stable. I follow the docs [here](https://docs.tigera.io/calico/latest/operations/ebpf/enabling-ebpf) and I am just integrating it into the template.

For anyone looking to migrate over, read the [docs](https://docs.tigera.io/calico/latest/operations/ebpf/enabling-ebpf) and the changes in this PR. You might need to reboot your cluster afterwords.

Feedback is appreciated. 