### PR TITLE
fix ingress.main.className for echo-server

### DIFF
--- a/kubernetes/apps/default/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo-server/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
     ingress:
       main:
         enabled: true
-        ingressClassName: nginx
+        className: nginx
         annotations:
           external-dns.alpha.kubernetes.io/target: "ipv4.${SECRET_DOMAIN}"
           hajimari.io/icon: video-input-antenna


### PR DESCRIPTION
echo-server failed to deploy using the ingress.main.ingressClassName setting from the template. Changing this to ingress.main.className allowed the service to deploy successfully.