### PR TITLE
fix: change Cilium IPAM mode to kubernetes

### DIFF
--- a/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
+++ b/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
@@ -40,10 +40,7 @@ spec:
         ingress:
           enabled: false
     ipam:
-      mode: cluster-pool
-      operator:
-        clusterPoolIPv4PodCIDRList: ["{{ cluster_cidr }}"]
-        clusterPoolIPv4MaskSize: 24
+      mode: kubernetes
     k8sServiceHost: "{{ kubevip_address }}"
     k8sServicePort: 6443
     kubeProxyReplacement: strict

--- a/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
+++ b/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
@@ -21,24 +21,7 @@ spec:
       integration: containerd
       socketPath: /var/run/k3s/containerd/containerd.sock
     hubble:
-      enabled: true
-      metrics:
-        enabled:
-          - dns:query;ignoreAAAA
-          - drop
-          - tcp
-          - flow
-          - port-distribution
-          - icmp
-          - http
-      relay:
-        enabled: true
-        rollOutPods: true
-      ui:
-        enabled: true
-        rollOutPods: true
-        ingress:
-          enabled: false
+      enabled: false
     ipam:
       mode: kubernetes
     k8sServiceHost: "{{ kubevip_address }}"
@@ -47,5 +30,3 @@ spec:
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     operator:
       replicas: 1
-      rollOutPods: true
-    rollOutCiliumPods: true

--- a/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
+++ b/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
@@ -46,7 +46,6 @@ spec:
     kubeProxyReplacement: strict
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     operator:
-      enabled: true
       replicas: 1
       rollOutPods: true
     rollOutCiliumPods: true

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -65,10 +65,7 @@ spec:
             - hosts:
                 - *host
     ipam:
-      mode: cluster-pool
-      operator:
-        clusterPoolIPv4PodCIDRList: ["${CLUSTER_CIDR}"]
-        clusterPoolIPv4MaskSize: 24
+      mode: kubernetes
     k8sServiceHost: "${KUBE_VIP_ADDR}"
     k8sServicePort: 6443
     kubeProxyReplacement: strict

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -71,7 +71,6 @@ spec:
     kubeProxyReplacement: strict
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     operator:
-      enabled: true
       replicas: 1
       rollOutPods: true
       prometheus:


### PR DESCRIPTION
This changes the ipam from `cluster-pool` to kubernetes, which I tested in my own cluster based off this templet.
This also removes the `operator: enabled` as it's set to true in the helm chart.