### PR TITLE
fix: remove error pages and default backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following components will be installed in your [k3s](https://k3s.io/) cluste
 - [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) - Kubernetes ingress controller used for a HTTP reverse proxy of Kubernetes ingresses
 - [local-path-provisioner](https://github.com/rancher/local-path-provisioner) - provision persistent local storage with Kubernetes
 
-_Additional applications include [hajimari](https://github.com/toboshii/hajimari), [error-pages](https://github.com/tarampampam/error-pages), [echo-server](https://github.com/Ealenn/Echo-Server), [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller), [reloader](https://github.com/stakater/Reloader), and [kured](https://github.com/weaveworks/kured)_
+_Additional applications include [hajimari](https://github.com/toboshii/hajimari), [echo-server](https://github.com/Ealenn/Echo-Server), [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller), [reloader](https://github.com/stakater/Reloader), and [kured](https://github.com/weaveworks/kured)_
 
 ## 📝 Prerequisites
 

--- a/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
@@ -43,7 +43,6 @@ spec:
         client-header-timeout: 120
         client-body-buffer-size: "100M"
         client-body-timeout: 120
-        custom-http-errors: 400,401,403,404,500,502,503,504
         enable-brotli: "true"
         hsts-max-age: "31449600"
         keep-alive: 120

--- a/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/ingress-nginx/app/helmrelease.yaml
@@ -65,10 +65,4 @@ spec:
         limits:
           memory: 500Mi
     defaultBackend:
-      enabled: true
-      image:
-        repository: ghcr.io/tarampampam/error-pages
-        tag: 2.24.0
-      extraEnvs:
-        - { name: TEMPLATE_NAME, value: lost-in-space }
-        - { name: SHOW_DETAILS, value: "false" }
+      enabled: false


### PR DESCRIPTION
If an application was throwing any error that is in this list, it forwarded that error to the default backend. A lot of 405 requests where POST requests which gave an 500 error, this resulting in the default backend to handle those requests, but that only accepts GET request, thus transforming the errors in 405. So in reality the real errors where masked, and the applications couldn't handle the error properly resulting in more issues.