### PR TITLE
Remove AnsibleTask no longer in use

### DIFF
--- a/.taskfiles/AnsibleTasks.yml
+++ b/.taskfiles/AnsibleTasks.yml
@@ -63,12 +63,6 @@ tasks:
     cmds:
       - ansible all -i {{.ANSIBLE_INVENTORY_DIR}}/hosts.yml --one-line -a 'uptime'
 
-  rollout-reboot:
-    desc: Rollout a reboot across all the k8s nodes
-    dir: "{{.ANSIBLE_DIR}}"
-    cmds:
-      - ansible-playbook -i {{.ANSIBLE_INVENTORY_DIR}}/hosts.yml {{.ANSIBLE_PLAYBOOK_DIR}}/cluster-rollout-reboot.yml
-
   force-reboot:
     desc: Reboot all the k8s nodes
     dir: "{{.ANSIBLE_DIR}}"


### PR DESCRIPTION
Removing Ansible `task ansible:rollout-reboot` since it's no longer in use, and the playbook was removed in [this commit](https://github.com/onedr0p/flux-cluster-template/commit/4b9b69eb41601d3389d42c377f47f6498b7a0e5f).