### PR TITLE
Update xargs argument in cluster tasks

### DIFF
--- a/.taskfiles/ClusterTasks.yml
+++ b/.taskfiles/ClusterTasks.yml
@@ -31,8 +31,8 @@ tasks:
   hr-restart:
     desc: Restart all failed Helm Releases
     cmds:
-      - kubectl get hr --all-namespaces | grep False | awk '{print $2, $1}' | xargs -l bash -c 'flux suspend hr $0 -n $1'
-      - kubectl get hr --all-namespaces | grep False | awk '{print $2, $1}' | xargs -l bash -c 'flux resume hr $0 -n $1'
+      - kubectl get hr --all-namespaces | grep False | awk '{print $2, $1}' | xargs -L1 bash -c 'flux suspend hr $0 -n $1'
+      - kubectl get hr --all-namespaces | grep False | awk '{print $2, $1}' | xargs -L1 bash -c 'flux resume hr $0 -n $1'
 
   nodes:
     desc: List all the nodes in your cluster


### PR DESCRIPTION
`xargs -L1` is equivalent and compatible with all platforms to `xargs -l` which is only gnu xargs specific. 

`xargs -l` is equivalent to `xargs -L1`