### PR TITLE
Check if ufw is installed before attempting to disable it

### DIFF
--- a/ansible/playbooks/cluster-prepare.yml
+++ b/ansible/playbooks/cluster-prepare.yml
@@ -65,17 +65,16 @@
 
     - name: System Configuration (1)
       block:
-        - name: System Configuration (1) | Check if ufw is installed/running
-          ansible.builtin.service_facts:
-        - name: System Configuration (1) | Disable ufw if needed
+        - name: System Configuration (1) | Disable ufw
           ansible.builtin.systemd:
             service: ufw.service
             enabled: false
             masked: true
             state: stopped
-          when:
-            - "'ufw' in ansible_facts.services"
-            - ansible_facts.services['ufw']['state'] == "running"
+          register: stop_service
+          failed_when:
+            - stop_service.failed == true
+            - '"Could not find the requested service" not in stop_service.msg'
         - name: System Configuration (1) | Enable fstrim
           ansible.builtin.systemd:
             service: fstrim.timer

--- a/ansible/playbooks/cluster-prepare.yml
+++ b/ansible/playbooks/cluster-prepare.yml
@@ -65,12 +65,17 @@
 
     - name: System Configuration (1)
       block:
-        - name: System Configuration (1) | Disable ufw
+        - name: System Configuration (1) | Check if ufw is installed/running
+          ansible.builtin.service_facts:
+        - name: System Configuration (1) | Disable ufw if needed
           ansible.builtin.systemd:
             service: ufw.service
             enabled: false
             masked: true
             state: stopped
+          when:
+            - "'ufw' in ansible_facts.services"
+            - ansible_facts.services['ufw']['state'] == "running"
         - name: System Configuration (1) | Enable fstrim
           ansible.builtin.systemd:
             service: fstrim.timer


### PR DESCRIPTION
Simple change that checks if ufw is installed and/or running before attempting to disable it with Ansible.

This fixes the playbook running against Debian machines, which although is not supported, is a good change to have nonetheless. 