### PR TITLE
feat(pre-commit): add renovate check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
           - --config-file
           - .yamllint.yaml
         id: yamllint
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 35.144.0
+    hooks:
+      - id: renovate-config-validator


### PR DESCRIPTION
Sometimes updating the renovate config file can be hard, so it's good to have a check before committing an invalid one.

Reference: https://docs.renovatebot.com/config-validation/