### PR TITLE
fix(metallb): Disable frr by default

### DIFF
--- a/kubernetes/apps/networking/metallb/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/metallb/app/helmrelease.yaml
@@ -29,6 +29,5 @@ spec:
     crds:
       enabled: true
     speaker:
-      enabled: true
       frr:
         enabled: false

--- a/kubernetes/apps/networking/metallb/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/metallb/app/helmrelease.yaml
@@ -28,3 +28,7 @@ spec:
   values:
     crds:
       enabled: true
+    speaker:
+      enabled: true
+      frr:
+        enabled: false


### PR DESCRIPTION
Disables frr by default. 

Enabled by default: https://github.com/metallb/metallb/blob/main/charts/metallb/values.yaml#L321