### PR TITLE
fix: Add hubble-ui hajimari icon

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -64,6 +64,8 @@ spec:
         ingress:
           enabled: true
           className: nginx
+          annotations:
+            hajimari.io/icon: "simple-icons:cilium"
           hosts:
             - &host "hubble.${SECRET_DOMAIN}"
           tls:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
           enabled: true
           className: nginx
           annotations:
-            hajimari.io/icon: "simple-icons:cilium"
+            hajimari.io/icon: simple-icons:cilium
           hosts:
             - &host "hubble.${SECRET_DOMAIN}"
           tls:


### PR DESCRIPTION
This change will add the cilium icon to hubble-ui inside hajimari, since by default it is the default application icon.