### PR TITLE
fix: Update hosts.yaml destination

### DIFF
--- a/template/defaults/templates.yaml
+++ b/template/defaults/templates.yaml
@@ -9,7 +9,7 @@ templates:
     dest: ./ansible/inventory/group_vars/kubernetes/supplemental.yaml
     encrypt: false
   - src: ansible/hosts.yaml.j2
-    dest: ./ansible/hosts.yaml
+    dest: ./ansible/inventory/hosts.yaml
     encrypt: false
   # Kubernetes dir
   - src: kubernetes/kube-prometheus-stack-helmrelease.yaml.j2


### PR DESCRIPTION
```
[WARNING]: Unable to parse /home/Rodent/home-ops/ansible/inventory/hosts.yaml as an inventory source
ERROR! No inventory was parsed, please check your configuration and options.
task: Failed to run task "ansible:list": exit status 1
```