### PR TITLE
Fix `cp` command on OSX

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -23,8 +23,8 @@ tasks:
     desc: Initialize configuration files
     dir: "{{.TEMPLATE_DIR}}"
     cmds:
-      - cp --no-clobber vars/addons.sample.yaml vars/addons.yaml
-      - cp --no-clobber vars/config.sample.yaml vars/config.yaml
+      - cp -n vars/addons.sample.yaml vars/addons.yaml
+      - cp -n vars/config.sample.yaml vars/config.yaml
       - cmd: echo "=== Configuration files copied ==="
         silent: true
       - cmd: echo "Proceed with updating the configuration files..."


### PR DESCRIPTION
When running the new `task:init` os OSX, I get the following error:

```
$ task init
task: [init] cp --no-clobber vars/addons.sample.yaml vars/addons.yaml
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file ... target_directory
task: Failed to run task "init": exit status 64
$
```

The `--no-clobber` option is non-POSIX, but GNU-specific. `-n` should work the same in Linux and OSX.