### PR TITLE
fix: brew deps - install yq

### DIFF
--- a/.taskfiles/BrewTasks.yaml
+++ b/.taskfiles/BrewTasks.yaml
@@ -26,3 +26,4 @@ tasks:
         python
         sops
         stern
+        yq


### PR DESCRIPTION
yq is used in the README, when pulling Flux webhook token