### PR TITLE
Feat: add package and additional comments required

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ According to the documentation [here](https://raspi.debian.net/defaults-and-sett
 3. Change `root_pw` to your desired root password.
 4. Change `hostname` to your desired hostname.
 
+[Post install] manually install `python3`, otherwise ansible will fail.
+
+    ```sh
+    su -
+    apt update
+    apt install python3
+    exit
+    ```
+
+You will also want to complete the additional steps outlined in [Debian for AMD64](#debian-for-amd64)
+
 ## 🚀 First Steps
 
 The very first step will be to create a new **public** repository by clicking the big green **Use this template** button on this page. Next clone **your new repo** to you local workstation and `cd` into it.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ There is a decent guide [here](https://www.linuxtechi.com/how-to-install-debian-
 
     ```sh
     su -
-    apt install sudo
+    apt install -y sudo
     usermod -aG sudo ${username}
     echo "${username} ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/${username}
     exit
@@ -77,7 +77,7 @@ There is a decent guide [here](https://www.linuxtechi.com/how-to-install-debian-
 
     ```sh
     mkdir -m 700 ~/.ssh
-    sudo apt install curl
+    sudo apt install -y curl
     curl https://github.com/${github_username}.keys > ~/.ssh/authorized_keys
     chmod 600 ~/.ssh/authorized_keys
     ```
@@ -94,17 +94,12 @@ According to the documentation [here](https://raspi.debian.net/defaults-and-sett
 2. Change `root_authorized_key` to your desired public SSH key.
 3. Change `root_pw` to your desired root password.
 4. Change `hostname` to your desired hostname.
-
-[Post install] manually install `python3`, otherwise ansible will fail.
+6. [Post install] Follow steps 3 & 4 from [Debian for AMD64](#debian-for-amd64) section.
+7. [Post install] Install `python3` which is needed by Ansible.
 
     ```sh
-    su -
-    apt update
-    apt install python3
-    exit
+    sudo apt install -y python3
     ```
-
-You will also want to complete the additional steps outlined in [Debian for AMD64](#debian-for-amd64)
 
 ## 🚀 First Steps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ansible==8.2.0
 ansible-lint==6.17.2
 bcrypt==4.0.1
+jmespath==1.0.1
 netaddr==0.8.0
 openshift==0.13.1
 passlib==1.7.4


### PR DESCRIPTION
This adds extra steps for Raspberry Pi setup based on recent experience (ansible failing on a fresh Deb12 RPi installation)
This also adds the `jmespath` package to the local .venv requirements, as it's required for `rollout-update`