### PR TITLE
fix: change labeler to match new directory structure

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,5 +1,6 @@
 ---
 area/ansible:
+  - "ansible/**/*"
   - "bootstrap/templates/ansible/**/*"
   - "bootstrap/tasks/ansible/**/*"
 area/github:

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -5,6 +5,7 @@ area/ansible:
 area/github:
   - ".github/**/*"
 area/kubernetes:
+  - "kubernetes/**/*"
   - "bootstrap/templates/kubernetes/**/*"
   - "bootstrap/tasks/kubernetes/**/*"
 area/bootstrap:

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,9 +1,16 @@
 ---
 area/ansible:
-  - "ansible/**/*"
+  - "bootstrap/templates/ansible/**/*"
+  - "bootstrap/tasks/ansible/**/*"
 area/github:
   - ".github/**/*"
 area/kubernetes:
-  - "kubernetes/**/*"
+  - "bootstrap/templates/kubernetes/**/*"
+  - "bootstrap/tasks/kubernetes/**/*"
 area/bootstrap:
   - "bootstrap/**/*"
+  - "bootstrap/configure.yaml"
+area/addons:
+  - "bootstrap/templates/addons/**/*"
+  - "bootstrap/tasks/addons/**/*"
+  - "bootstrap/vars/addons.sample.yaml"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -12,10 +12,10 @@
   color: "72ccf3"
   description: >-
     Changes made in the kubernetes directory
-- name: area/template
+- name: area/addons
   color: "72ccf3"
   description: >-
-    Changes made in the template directory
+    Changes made in the addons directory
 # Renovate
 - name: renovate/ansible
   color: "ffc300"


### PR DESCRIPTION
Labeler currently does not reflect the new folder structure, so everything will just be labeled `area/bootstrap`