### PR TITLE
update ingress classNames in HelmReleases

### DIFF
--- a/bootstrap/templates/addons/kubernetes-dashboard/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/addons/kubernetes-dashboard/app/helmrelease.yaml.j2
@@ -34,7 +34,7 @@ spec:
     app:
       ingress:
         enabled: true
-        className: nginx
+        className: internal
         annotations:
           hajimari.io/icon: mdi:kubernetes
         hosts:

--- a/bootstrap/templates/addons/weave-gitops/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/addons/weave-gitops/app/helmrelease.yaml.j2
@@ -31,7 +31,7 @@ spec:
       username: admin
     ingress:
       enabled: true
-      className: nginx
+      className: internal
       annotations:
         hajimari.io/icon: sawtooth-wave
       hosts:

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -67,7 +67,7 @@ spec:
         rollOutPods: true
         ingress:
           enabled: true
-          className: nginx
+          className: internal
           annotations:
             hajimari.io/icon: simple-icons:cilium
           hosts:


### PR DESCRIPTION
Updated ingress className in HelmReleases for `cilium`, `kubernetes-dashboard` and `weave-gitops` so that their URLs resolve.