### PR TITLE
fix(cloudflared): fixed origin server name

### DIFF
--- a/bootstrap/templates/kubernetes/apps/networking/cloudflared/app/configs/config.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/networking/cloudflared/app/configs/config.yaml.j2
@@ -6,9 +6,9 @@ ingress:
   - hostname: "${SECRET_DOMAIN}"
     service: https://nginx-external-controller.networking.svc.cluster.local:443
     originRequest:
-      originServerName: "ingress.${SECRET_DOMAIN}"
+      originServerName: "external.${SECRET_DOMAIN}"
   - hostname: "*.${SECRET_DOMAIN}"
     service: https://nginx-external-controller.networking.svc.cluster.local:443
     originRequest:
-      originServerName: "ingress.${SECRET_DOMAIN}"
+      originServerName: "external.${SECRET_DOMAIN}"
   - service: http_status:404


### PR DESCRIPTION
As per title, these should be renamed to external instead of the old ingress