### PR TITLE
Rename internal/external nginx to ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ The `external-dns` application created in the `networking` namespace will handle
 
 2. Restart dnsmasq on the server.
 
-3. Query an internal-only subdomain from your workstation: `dig @${home-dns-server-ip} echo-server.${bootstrap_cloudflare_domain}`. It should resolve to `${bootstrap_internal_nginx_addr}`.
+3. Query an internal-only subdomain from your workstation: `dig @${home-dns-server-ip} echo-server.${bootstrap_cloudflare_domain}`. It should resolve to `${bootstrap_internal_ingress_addr}`.
 
 If you're having trouble with DNS be sure to check out these two GitHub discussions: [Internal DNS](https://github.com/onedr0p/flux-cluster-template/discussions/719) and [Pod DNS resolution broken](https://github.com/onedr0p/flux-cluster-template/discussions/635).
 

--- a/bootstrap/tasks/validation/net.yaml
+++ b/bootstrap/tasks/validation/net.yaml
@@ -67,29 +67,29 @@
     success_msg: k8s_gateway address {{ bootstrap_k8s_gateway_addr }} is within {{ bootstrap_node_cidr }}.
     fail_msg: k8s_gateway address {{ bootstrap_k8s_gateway_addr }} is not within {{ bootstrap_node_cidr }}.
 
-- name: Verify internal nginx
+- name: Verify internal ingress
   ansible.builtin.assert:
-    that: bootstrap_internal_nginx_addr is ansible.utils.ipv4
-    success_msg: internal nginx address {{ bootstrap_internal_nginx_addr }} is valid.
-    fail_msg: internal nginx address {{ bootstrap_internal_nginx_addr }} is invalid.
+    that: bootstrap_internal_ingress_addr is ansible.utils.ipv4
+    success_msg: internal ingress address {{ bootstrap_internal_ingress_addr }} is valid.
+    fail_msg: internal ingress address {{ bootstrap_internal_ingress_addr }} is invalid.
 
-- name: Verify internal nginx in node CIDR
+- name: Verify internal ingress in node CIDR
   ansible.builtin.assert:
-    that: bootstrap_node_cidr | ansible.utils.network_in_usable(bootstrap_internal_nginx_addr)
-    success_msg: internal nginx address {{ bootstrap_internal_nginx_addr }} is within {{ bootstrap_node_cidr }}.
-    fail_msg: internal nginx address {{ bootstrap_internal_nginx_addr }} is not within {{ bootstrap_node_cidr }}.
+    that: bootstrap_node_cidr | ansible.utils.network_in_usable(bootstrap_internal_ingress_addr)
+    success_msg: internal ingress address {{ bootstrap_internal_ingress_addr }} is within {{ bootstrap_node_cidr }}.
+    fail_msg: internal ingress address {{ bootstrap_internal_ingress_addr }} is not within {{ bootstrap_node_cidr }}.
 
-- name: Verify external nginx
+- name: Verify external ingress
   ansible.builtin.assert:
-    that: bootstrap_external_nginx_addr is ansible.utils.ipv4
-    success_msg: external nginx address {{ bootstrap_external_nginx_addr }} is valid.
-    fail_msg: external nginx address {{ bootstrap_external_nginx_addr }} is invalid.
+    that: bootstrap_external_ingress_addr is ansible.utils.ipv4
+    success_msg: external ingress address {{ bootstrap_external_ingress_addr }} is valid.
+    fail_msg: external ingress address {{ bootstrap_external_ingress_addr }} is invalid.
 
-- name: Verify external nginx in node CIDR
+- name: Verify external ingress in node CIDR
   ansible.builtin.assert:
-    that: bootstrap_node_cidr | ansible.utils.network_in_usable(bootstrap_external_nginx_addr)
-    success_msg: external nginx address {{ bootstrap_external_nginx_addr }} is within {{ bootstrap_node_cidr }}.
-    fail_msg: external nginx address {{ bootstrap_external_nginx_addr }} is not within {{ bootstrap_node_cidr }}.
+    that: bootstrap_node_cidr | ansible.utils.network_in_usable(bootstrap_external_ingress_addr)
+    success_msg: external ingress address {{ bootstrap_external_ingress_addr }} is within {{ bootstrap_node_cidr }}.
+    fail_msg: external ingress address {{ bootstrap_external_ingress_addr }} is not within {{ bootstrap_node_cidr }}.
 
 - name: Verify kube-vip
   ansible.builtin.assert:
@@ -108,16 +108,16 @@
     that: >
       [
         bootstrap_k8s_gateway_addr,
-        bootstrap_external_nginx_addr,
-        bootstrap_internal_nginx_addr,
+        bootstrap_external_ingress_addr,
+        bootstrap_internal_ingress_addr,
         bootstrap_kube_vip_addr
       ] | unique | length == 4
     success_msg: All IP addresses are unique.
     fail_msg: All IP addresses are not unique.
 
-- name: Verify nodes are not the same IPs as k8s_gateway, nginx external/internal or kube-vip
+- name: Verify nodes are not the same IPs as k8s_gateway, ingress external/internal or kube-vip
   ansible.builtin.assert:
-    that: item.address not in (bootstrap_k8s_gateway_addr, bootstrap_external_nginx_addr, bootstrap_internal_nginx_addr, bootstrap_kube_vip_addr)
+    that: item.address not in (bootstrap_k8s_gateway_addr, bootstrap_external_ingress_addr, bootstrap_internal_ingress_addr, bootstrap_kube_vip_addr)
     success_msg: Node address {{ item.address }} is different than k8s_gateway, ingress-nginx or kube-vip.
     fail_msg: Node address {{ item.address }} is not different than k8s_gateway, ingress-nginx or kube-vip.
     quiet: true

--- a/bootstrap/tasks/validation/vars.yaml
+++ b/bootstrap/tasks/validation/vars.yaml
@@ -17,8 +17,8 @@
     - bootstrap_flux_github_webhook_token
     - bootstrap_github_repository_name
     - bootstrap_github_username
-    - bootstrap_external_nginx_addr
-    - bootstrap_internal_nginx_addr
+    - bootstrap_external_ingress_addr
+    - bootstrap_internal_ingress_addr
     - bootstrap_ipv6_enabled
     - bootstrap_k8s_gateway_addr
     - bootstrap_kube_vip_addr

--- a/bootstrap/templates/kubernetes/apps/networking/nginx/external/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/networking/nginx/external/helmrelease.yaml.j2
@@ -35,7 +35,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "{{ bootstrap_external_nginx_addr }}"
+          io.cilium/lb-ipam-ips: "{{ bootstrap_external_ingress_addr }}"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: external

--- a/bootstrap/templates/kubernetes/apps/networking/nginx/internal/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/networking/nginx/internal/helmrelease.yaml.j2
@@ -32,7 +32,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "internal.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "{{ bootstrap_internal_nginx_addr }}"
+          io.cilium/lb-ipam-ips: "{{ bootstrap_internal_ingress_addr }}"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: internal

--- a/bootstrap/vars/config.sample.yaml
+++ b/bootstrap/vars/config.sample.yaml
@@ -40,10 +40,10 @@ bootstrap_node_cidr:
 bootstrap_kube_vip_addr:
 # The Load balancer IP for k8s_gateway, choose an available IP in your nodes network that is not being used
 bootstrap_k8s_gateway_addr:
-# The Load balancer IP for external nginx, choose an available IP in your nodes network that is not being used
-bootstrap_external_nginx_addr:
-# The Load balancer IP for internal nginx, choose an available IP in your nodes network that is not being used
-bootstrap_internal_nginx_addr:
+# The Load balancer IP for external ingress, choose an available IP in your nodes network that is not being used
+bootstrap_external_ingress_addr:
+# The Load balancer IP for internal ingress, choose an available IP in your nodes network that is not being used
+bootstrap_internal_ingress_addr:
 
 # Keep the next three options default unless you know what you are doing
 # (Advanced) Enable ipv6


### PR DESCRIPTION
This is more a cosmetic change, renaming internal/external nginx to internal/external ingress to have technology agnostic variables.