### PR TITLE
fix: kubernetes-dashboard version 7.x.x was yanked from the helm repo

### DIFF
--- a/bootstrap/templates/addons/kubernetes-dashboard/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/addons/kubernetes-dashboard/app/helmrelease.yaml.j2
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: kubernetes-dashboard
-      version: 7.0.3
+      version: 6.0.8
       sourceRef:
         kind: HelmRepository
         name: kubernetes-dashboard
@@ -25,31 +25,20 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    api:
-      containers:
-        args:
-          - --enable-insecure-login=true
-          - --enable-skip-login=true
-          - --disable-settings-authorizer=true
-    app:
-      ingress:
-        enabled: true
-        className: internal
-        annotations:
-          hajimari.io/icon: mdi:kubernetes
-        hosts:
-          - &host "kubernetes.${SECRET_DOMAIN}"
-        tls:
-          - hosts:
-              - *host
-            secretName: kubernetes-dashboard-tls
+    extraArgs:
+      - --enable-insecure-login
+      - --enable-skip-login
+      - --disable-settings-authorizer
+    ingress:
+      enabled: true
+      className: internal
+      annotations:
+        hajimari.io/icon: mdi:kubernetes
+      hosts:
+        - &host "kubernetes.${SECRET_DOMAIN}"
+      tls:
+        - hosts:
+            - *host
+          secretName: kubernetes-dashboard-tls
     metricsScraper:
       enabled: true
-    serviceMonitor:
-      enabled: false
-    cert-manager:
-      enabled: false
-    nginx:
-      enabled: false
-    metrics-server:
-      enabled: false


### PR DESCRIPTION
According to [this issue](https://github.com/kubernetes/dashboard/issues/8191), 7.x is not stable, but the helm chart was published as if it were. They since manually yanked the 7.x versions, causing deployment errors with this chart. This reverts the version to stable 6.x.