### PR TITLE
feat(ansible): add branch reference as variable in gitrepository

### DIFF
--- a/bootstrap/tasks/validation/github.yaml
+++ b/bootstrap/tasks/validation/github.yaml
@@ -26,3 +26,17 @@
     that: result.json.full_name == bootstrap_github_username + '/' + bootstrap_github_repository_name
     success_msg: Github repo {{ bootstrap_github_username }}/{{ bootstrap_github_repository_name }} exists
     fail_msg: Github repo {{ bootstrap_github_username }}/{{ bootstrap_github_repository_name }} does not exist
+
+- name: Query Github repo branch
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/{{ bootstrap_github_username }}/{{ bootstrap_github_repository_name }}/branches/{{ bootstrap_github_repository_branch | default('main', true) }}
+    timeout: 5
+    return_content: true
+    body_format: json
+  register: result
+
+- name: Check if repo branch exists
+  ansible.builtin.assert:
+    that: result.json.name == bootstrap_github_repository_branch | default('main', true)
+    success_msg: Github repo branch {{ bootstrap_github_repository_branch | default('main', true) }} exists
+    fail_msg: Github repo branch {{ bootstrap_github_repository_branch | default('main', true) }} does not exist

--- a/bootstrap/tasks/validation/vars.yaml
+++ b/bootstrap/tasks/validation/vars.yaml
@@ -16,6 +16,7 @@
     - bootstrap_cluster_cidr
     - bootstrap_flux_github_webhook_token
     - bootstrap_github_repository_name
+    - bootstrap_github_repository_branch
     - bootstrap_github_username
     - bootstrap_external_ingress_addr
     - bootstrap_internal_ingress_addr

--- a/bootstrap/templates/kubernetes/flux/config/cluster.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/config/cluster.yaml.j2
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 30m
   ref:
-    branch: main
+    branch: {{ bootstrap_github_repository_branch | default('main', true) }}
   url: "https://github.com/{{ bootstrap_github_username }}/{{ bootstrap_github_repository_name }}.git"
   ignore: |
     # exclude all

--- a/bootstrap/vars/config.sample.yaml
+++ b/bootstrap/vars/config.sample.yaml
@@ -8,7 +8,7 @@ bootstrap_github_username:
 # Github repository (e.g. flux-cluster-template)
 bootstrap_github_repository_name:
 # Github repository branch (e.g. main)
-bootstrap_github_repository_branch:
+bootstrap_github_repository_branch: main
 # Age Public Key (e.g. age15uzrw396e67z9wdzsxzdk7ka0g2gr3l460e0slaea563zll3hdfqwqxdta)
 bootstrap_age_public_key:
 # Choose your timezone (e.g. America/New_York)

--- a/bootstrap/vars/config.sample.yaml
+++ b/bootstrap/vars/config.sample.yaml
@@ -7,6 +7,8 @@
 bootstrap_github_username:
 # Github repository (e.g. flux-cluster-template)
 bootstrap_github_repository_name:
+# Github repository branch (e.g. main)
+bootstrap_github_repository_branch:
 # Age Public Key (e.g. age15uzrw396e67z9wdzsxzdk7ka0g2gr3l460e0slaea563zll3hdfqwqxdta)
 bootstrap_age_public_key:
 # Choose your timezone (e.g. America/New_York)


### PR DESCRIPTION
The Flux GitRepository kind allows for configuring the branch reference. Currently, the value is fixed at 'main' in the 'flux-cluster-template' project. This pull request allows configuring the desired branch to be used in the GitRepository manifest.

The code has been tested with different values for the variable `bootstrap_github_repository_branch` and the results were correct. Let me know if you need this results. 