### PR TITLE
Adding permission to read repo on flux-diff workflow (mandatory for private repos)

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Flux Diff
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     strategy:
       matrix:


### PR DESCRIPTION
If you want to use the flux-diff workflow on a private home-ops repository the added permission is needed. If it is not given the `Diff Resources` step would fail on `Fetching the repository` with the following error message: 

```
remote: Repository not found.
Error: fatal: repository 'https://github.com/janpfischer/home-ops/' not found
```

Adding this permission allows the job to read the content of the private repo. For public repo's this should not make any difference. 