### PR TITLE
Fix echo-server template ingress className

### DIFF
--- a/bootstrap/templates/kubernetes/apps/networking/echo-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/networking/echo-server/app/helmrelease.yaml.j2
@@ -70,7 +70,7 @@ spec:
     ingress:
       main:
         enabled: true
-        ingressClassName: external
+        className: external
         annotations:
           external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
           hajimari.io/icon: video-input-antenna


### PR DESCRIPTION
The app-template chart v2 removes `ingressClassName` in favor of `className`, ingress creation breaks if the former is left in place. 

This is the only file I caught using the app template and specifying the ingress, but it caught me out when I was upgrading to 2.0.3