### PR TITLE
fix(system-upgrade): fix race condition

### DIFF
--- a/bootstrap/templates/addons/system-upgrade-controller/app/rbac.yaml.j2
+++ b/bootstrap/templates/addons/system-upgrade-controller/app/rbac.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: system-upgrade
+  labels: app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Currently, on a fresh deploy, the `helmrelease` will fail, as the RBAC is created, but unable to be managed by helm, showing the following error:

```
reconciliation failed: Helm install failed: rendered manifests contain a resource that already exists. Unable to continue with install: ServiceAccount "system-upgrade" in namespace "system-upgrade" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "system-upgrade-controller"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "system-upgrade"
```