### PR TITLE
Fixed: topology for ingress-nginx instances due to labels not matching

### DIFF
--- a/bootstrap/templates/kubernetes/apps/networking/nginx/external/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/networking/nginx/external/helmrelease.yaml.j2
@@ -85,7 +85,8 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              app.kubernetes.io/name: nginx-external
+              app.kubernetes.io/name: ingress-nginx
+              app.kubernetes.io/instance: nginx-external
               app.kubernetes.io/component: controller
       resources:
         requests:

--- a/bootstrap/templates/kubernetes/apps/networking/nginx/internal/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/networking/nginx/internal/helmrelease.yaml.j2
@@ -82,7 +82,8 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              app.kubernetes.io/name: nginx-internal
+              app.kubernetes.io/name: ingress-nginx
+              app.kubernetes.io/instance: nginx-internal
               app.kubernetes.io/component: controller
       resources:
         requests:


### PR DESCRIPTION
nginx instances were not following topology Constraints due to mismatching labels. They chose to be together and fall when the node fell. :)