### PR TITLE
System Upgrade Controller install failed due to missing /etc/pki dir

### DIFF
--- a/bootstrap/templates/addons/system-upgrade-controller/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/addons/system-upgrade-controller/app/helmrelease.yaml.j2
@@ -83,21 +83,21 @@ spec:
       etc-ssl:
         type: hostPath
         hostPath: /etc/ssl
-        hostPathType: Directory
+        hostPathType: DirectoryOrCreate
         globalMounts:
           - path: /etc/ssl
             readOnly: true
       etc-pki:
         type: hostPath
         hostPath: /etc/pki
-        hostPathType: Directory
+        hostPathType: DirectoryOrCreate
         globalMounts:
           - path: /etc/pki
             readOnly: true
       etc-ca-certificates:
         type: hostPath
         hostPath: /etc/ca-certificates
-        hostPathType: Directory
+        hostPathType: DirectoryOrCreate
         globalMounts:
           - path: /etc/ca-certificates
             readOnly: true

--- a/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
@@ -129,6 +129,13 @@
               fs.inotify.max_queued_events: 65536
               fs.inotify.max_user_watches: 524288
               fs.inotify.max_user_instances: 8192
+        - name: Create /etc/pki
+          ansible.builtin.file:
+            path: /etc/pki
+            state: directory
+            owner: root
+            group: root
+            mode: 0755
 
   handlers:
     - name: Reboot

--- a/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
@@ -129,13 +129,6 @@
               fs.inotify.max_queued_events: 65536
               fs.inotify.max_user_watches: 524288
               fs.inotify.max_user_instances: 8192
-        - name: Create /etc/pki
-          ansible.builtin.file:
-            path: /etc/pki
-            state: directory
-            owner: root
-            group: root
-            mode: 0755
 
   handlers:
     - name: Reboot


### PR DESCRIPTION
During a ground up rebuild I noticed that the System Upgrade Controller deployment failed because it could not mount /etc/pki on the host. so I created a task in cluster-prepare.yaml to do so.

## Error
```
MountVolume.SetUp failed for volume "etc-pki" : hostPath type check failed: /etc/pki is not a directory
```