### PR TITLE
[bootstrap] fix: remove conflicting condition for immutable flag and state:absent

### DIFF
--- a/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
@@ -9,7 +9,7 @@
       ansible.builtin.pause:
         seconds: 5
     - name: Populate service facts
-      service_facts:
+      ansible.builtin.service_facts:
   tasks:
     - name: Locale
       block:
@@ -73,6 +73,10 @@
             regexp: ManageForeignRoutes
             line: ManageForeignRoutes=no
         # https://github.com/onedr0p/flux-cluster-template/discussions/635
+        - name: Network Configuration | Remove immutable flag from /etc/resolv.conf
+          ansible.builtin.file:
+            attributes: -i
+            path: /etc/resolv.conf
         - name: Network Configuration | Remove /etc/resolv.conf
           ansible.builtin.file:
             attributes: -i
@@ -81,7 +85,7 @@
         - name: Network Configuration | Add custom /etc/resolv.conf
           ansible.builtin.copy:
             attributes: +i
-            mode: 644
+            mode: '0644'
             dest: /etc/resolv.conf
             content: |
               search .


### PR DESCRIPTION
When trying to run the Ansible node preparation script after the first run, below error gets thrown because Ansible is trying to remove the immutable flag AND delete the file at the same time (apparently it's not smart enough to do the attributes first). By adding an additional step to nuke the immutable attribute, this allows the preparation script to be run multiple times. Also includes some minor lints for Ansible style in that same Jinja2 file.

```
TASK [Network Configuration | Stop systemd-resolved] *****************************************************************************************************************
changed: [k3s-master-0]
changed: [k3s-worker-2]
changed: [k3s-worker-1]
changed: [k3s-worker-0]

TASK [Network Configuration | Remove /etc/resolv.conf] ***************************************************************************************************************
fatal: [k3s-worker-0]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "01204", "msg": "unlinking failed: [Errno 1] Operation not permitted: b'/etc/r
esolv.conf' ", "owner": "root", "path": "/etc/resolv.conf", "size": 28, "state": "file", "uid": 0}
fatal: [k3s-master-0]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "01204", "msg": "unlinking failed: [Errno 1] Operation not permitted: b'/etc/r
esolv.conf' ", "owner": "root", "path": "/etc/resolv.conf", "size": 28, "state": "file", "uid": 0}
fatal: [k3s-worker-1]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "01204", "msg": "unlinking failed: [Errno 1] Operation not permitted: b'/etc/r
esolv.conf' ", "owner": "root", "path": "/etc/resolv.conf", "size": 28, "state": "file", "uid": 0}
fatal: [k3s-worker-2]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "01204", "msg": "unlinking failed: [Errno 1] Operation not permitted: b'/etc/r
esolv.conf' ", "owner": "root", "path": "/etc/resolv.conf", "size": 28, "state": "file", "uid": 0}
```

And with this new step added:

```
TASK [Network Configuration | Remove immutable flag from /etc/resolv.conf] *******************************************************************************************
changed: [k3s-master-0]                                                                                                                                               
changed: [k3s-worker-0]                                                                                                                                               
changed: [k3s-worker-1]                                                                                                                                               
changed: [k3s-worker-2]                                                                                                                                               
                                                                                                                                                                      
TASK [Network Configuration | Remove /etc/resolv.conf] ***************************************************************************************************************
changed: [k3s-worker-0]                                                                                                                                               
changed: [k3s-master-0]                                                                                                                                               
changed: [k3s-worker-1]                                                                                                                                               
changed: [k3s-worker-2]                                                                                                                                               
                                                                                                                                                                      
TASK [Network Configuration | Add custom /etc/resolv.conf] ***********************************************************************************************************
changed: [k3s-worker-0]                                                                                                                                               
changed: [k3s-master-0]                                                                                                                                               
changed: [k3s-worker-2]                                                                                                                                               
changed: [k3s-worker-1]      
```