### PR TITLE
[bootstrap] feat: target cluster ansible plays only to kubernetes in case other hosts are used

### DIFF
--- a/bootstrap/templates/ansible/playbooks/cluster-installation.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-installation.yaml.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
 ---
 - name: Cluster Installation
-  hosts: all
+  hosts: kubernetes
   become: true
   gather_facts: true
   any_errors_fatal: true

--- a/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
@@ -1,6 +1,6 @@
 ---
 - name: Cluster Nuke
-  hosts: all
+  hosts: kubernetes
   become: true
   gather_facts: true
   any_errors_fatal: true

--- a/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-prepare.yaml.j2
@@ -1,6 +1,6 @@
 ---
 - name: Prepare System
-  hosts: all
+  hosts: kubernetes
   become: true
   gather_facts: true
   any_errors_fatal: true

--- a/bootstrap/templates/ansible/playbooks/cluster-reboot.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-reboot.yaml.j2
@@ -1,6 +1,6 @@
 ---
 - name: Reboot
-  hosts: all
+  hosts: kubernetes
   become: true
   gather_facts: true
   any_errors_fatal: true

--- a/bootstrap/templates/ansible/playbooks/cluster-rollout-update.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-rollout-update.yaml.j2
@@ -1,7 +1,7 @@
 ---
 # https://github.com/kevincoakley/ansible-role-k8s-rolling-update
 - name: Cluster rollout update
-  hosts: all
+  hosts: kubernetes
   become: true
   gather_facts: true
   any_errors_fatal: true


### PR DESCRIPTION
Based on template's Ansible inventory, all k8s nodes are under `kubernetes` inventory group. In my use case, I've also got a proxmox I want to manage so targeting `all` isn't appropriate. This PR changes the `hosts: all` for cluster node plays to target `kubernetes` appropriately, allowing folks to extend their hosts file as needed. 