### PR TITLE
[bootstrap] fix: fixed required variable validation assertion

### DIFF
--- a/bootstrap/tasks/validation/vars.yaml
+++ b/bootstrap/tasks/validation/vars.yaml
@@ -1,8 +1,9 @@
 ---
-
 - name: Verify required bootstrap vars are set
   ansible.builtin.assert:
-    that: item | default('', true) | trim != ''
+    that:
+      - vars[item] is defined
+      - vars[item] | default('', true) | trim != ''
     success_msg: Required bootstrap var {{ item }} exists and is defined
     fail_msg: Required bootstrap var {{ item }} does not exists or is not defined
   loop:
@@ -34,4 +35,4 @@
     fail_msg: Node name {{ item.name }} is not valid
   loop: "{{ bootstrap_nodes.master + bootstrap_nodes.worker | default([]) }}"
   loop_control:
-     label: "{{ item.name }}"
+    label: "{{ item.name }}"


### PR DESCRIPTION
The variable validation task would always evaluate to true as the assert module seems to just be treating the variable names as strings.


Now we check that the variable exist in the `vars` object and it is defined.


