### PR TITLE
[readme] specify an actual internal ingress for conditional DNS forwarding test

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ The `external-dns` application created in the `networking` namespace will handle
 
 2. Restart dnsmasq on the server.
 
-3. Query an internal-only subdomain from your workstation: `dig @${home-dns-server-ip} echo-server.${bootstrap_cloudflare_domain}`. It should resolve to `${bootstrap_internal_ingress_addr}`.
+3. Query an internal-only subdomain from your workstation (any `internal` class ingresses): `dig @${home-dns-server-ip} hubble.${bootstrap_cloudflare_domain}`. It should resolve to `${bootstrap_internal_ingress_addr}`.
 
 If you're having trouble with DNS be sure to check out these two GitHub discussions: [Internal DNS](https://github.com/onedr0p/flux-cluster-template/discussions/719) and [Pod DNS resolution broken](https://github.com/onedr0p/flux-cluster-template/discussions/635).
 


### PR DESCRIPTION
Noted a slight oopsiedoodle in the Home DNS resolution section referring to `echo-server` to test internal DNS resolution via dns conditional forwarding. We have Cilium's Hubble as an internal ingress so that should do the job just fine. Clarify that any `internal` class ingress would work too, if folks have added additional apps/services. 