### PR TITLE
Revert "[bootstrap] fix: fixed required variable validation assertion"

### DIFF
--- a/bootstrap/tasks/validation/vars.yaml
+++ b/bootstrap/tasks/validation/vars.yaml
@@ -1,9 +1,8 @@
 ---
+
 - name: Verify required bootstrap vars are set
   ansible.builtin.assert:
-    that:
-      - vars[item] is defined
-      - vars[item] | default('', true) | trim != ''
+    that: item | default('', true) | trim != ''
     success_msg: Required bootstrap var {{ item }} exists and is defined
     fail_msg: Required bootstrap var {{ item }} does not exists or is not defined
   loop:
@@ -35,4 +34,4 @@
     fail_msg: Node name {{ item.name }} is not valid
   loop: "{{ bootstrap_nodes.master + bootstrap_nodes.worker | default([]) }}"
   loop_control:
-    label: "{{ item.name }}"
+     label: "{{ item.name }}"


### PR DESCRIPTION
Reverts onedr0p/flux-cluster-template#1074


I made a mistake on testing this PR. 

The Jinja `default()` filter does not play nice with boolean variables. Any false-y variables ( e.g. `bootstrap_ipv6_enabled: false` ) will fail the assertion.

Without setting the default filters `boolean` paramater to `true`  the filters scope is limited strictly to `Undefined` which Ansible does not seem to assign to variables that are... undefined. 

```python
def do_default(value, default_value=u'', boolean=False):
    """If the value is undefined it will return the passed default value,
    otherwise the value of the variable:

    .. sourcecode:: jinja

        {{ my_variable|default('my_variable is not defined') }}

    This will output the value of ``my_variable`` if the variable was
    defined, otherwise ``'my_variable is not defined'``. If you want
    to use default with variables that evaluate to false you have to
    set the second parameter to `true`:

    .. sourcecode:: jinja

        {{ ''|default('the string was empty', true) }}
    """
    if isinstance(value, Undefined) or (boolean and not value):
        return default_value
    return value
```
