### PR TITLE
[bootstrap] fix: Fixed required variable validation assertions

### DIFF
--- a/bootstrap/tasks/validation/vars.yaml
+++ b/bootstrap/tasks/validation/vars.yaml
@@ -2,8 +2,8 @@
 - name: Verify required bootstrap vars are set
   ansible.builtin.assert:
     that:
-      - vars[item] is defined
-      - vars[item] | default('', true) | trim != ''
+      - item in vars
+      - vars[item] != None
     success_msg: Required bootstrap var {{ item }} exists and is defined
     fail_msg: Required bootstrap var {{ item }} does not exists or is not defined
   loop:

--- a/bootstrap/tasks/validation/vars.yaml
+++ b/bootstrap/tasks/validation/vars.yaml
@@ -1,8 +1,9 @@
 ---
-
 - name: Verify required bootstrap vars are set
   ansible.builtin.assert:
-    that: item | default('', true) | trim != ''
+    that:
+      - vars[item] is defined
+      - vars[item] | default('', true) | trim != ''
     success_msg: Required bootstrap var {{ item }} exists and is defined
     fail_msg: Required bootstrap var {{ item }} does not exists or is not defined
   loop:
@@ -34,4 +35,4 @@
     fail_msg: Node name {{ item.name }} is not valid
   loop: "{{ bootstrap_nodes.master + bootstrap_nodes.worker | default([]) }}"
   loop_control:
-     label: "{{ item.name }}"
+    label: "{{ item.name }}"


### PR DESCRIPTION
Turns out it was much simpler than I originally thought.

- `item in vars` checks that the variable exists in the `vars` object
- `vars[item] != None` checks that the variable is set

Empty variables are assigned as `null` by Ansible which Python then translates into `None`. 