### PR TITLE
fix: configure task to use cmds in taskfile

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -61,7 +61,8 @@ tasks:
     summary: task {{.TASK}}
     prompt: Any conflicting config in the root kubernetes and ansible directories will be overwritten... continue?
     dir: "{{.BOOTSTRAP_DIR}}"
-    cmd: ansible-playbook configure.yaml
+    cmds:
+      - ansible-playbook configure.yaml
     env:
       ANSIBLE_DISPLAY_SKIPPED_HOSTS: "false"
 


### PR DESCRIPTION
It looks like go-task use `cmds` as base entrypoint. Running `task configure` in the current state does not run the `cmd`.