### PR TITLE
Fix SOPS_AGE_KEY_FILE env variable in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "containerEnv": {
     "KUBECONFIG": "${containerWorkspaceFolder}/kubeconfig",
-    "SOPS_AGE_KEY_FILE": "${containerWorkspaceFolder}/.age.key"
+    "SOPS_AGE_KEY_FILE": "${containerWorkspaceFolder}/age.key"
   },
   "postCreateCommand": {
     "deps": "task deps"


### PR DESCRIPTION
In [Stage 3](https://github.com/onedr0p/flux-cluster-template?tab=readme-ov-file#-stage-3-do-bootstrap-configuration) of the README file, we create the key file as `age.key`, but in `SOPS_AGE_KEY_FILE` env variable of the dev container its defined with a preceding dot. This PR fixes this inconsistency (which makes command using the key fail).