### PR TITLE
Add direnv to dev container definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
     "ghcr.io/devcontainers-contrib/features/age:1": {},
     "ghcr.io/devcontainers-contrib/features/cloudflared:1": {},
     "ghcr.io/devcontainers-contrib/features/go-task:1": {},
+    "ghcr.io/devcontainers-contrib/features/direnv:1": {},
     "ghcr.io/devcontainers-contrib/features/sops:1": {},
     "ghcr.io/audacioustux/devcontainers/cilium:1": {},
     "ghcr.io/dhoeric/features/stern:1": {},


### PR DESCRIPTION
This PR adds direnv to dev container, but doesn't properly fix #1106 (we still need to hook it to the shell ourselves). I'm just adding it to get some feedback from direnv feature maintainers.