### PR TITLE
fix: Bump Homepage Memory Req & Limit

### DIFF
--- a/bootstrap/templates/addons/homepage/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/addons/homepage/app/helmrelease.yaml.j2
@@ -43,9 +43,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 100M
-              limits:
                 memory: 250M
+              limits:
+                memory: 2G
     service:
       main:
         ports:


### PR DESCRIPTION
Just running default widgets causes the container to get OOM killed. Bumping up to more reasonable limits.