### PR TITLE
add IPv6 cidr to CiliumLoadBalancerIPPool resource

### DIFF
--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-l2.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-l2.yaml.j2
@@ -20,3 +20,6 @@ metadata:
 spec:
   cidrs:
     - cidr: "${NODE_CIDR}"
+    {% if not bootstrap_ipv6_enabled | default(false) %}
+    - cidr: "${NODE_CIDR_V6}"
+    {% endif %}

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
@@ -3,8 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  {% if not bootstrap_ipv6_enabled | default(false) %}
   - ./cilium-l2.yaml
-  {% endif %}
   - ./helmvalues.yaml
   - ./helmrelease.yaml

--- a/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
@@ -11,8 +11,9 @@ data:
   KUBEAPI_ADDR: "{{ bootstrap_kubeapi_addr }}"
   CLUSTER_CIDR: "{{ bootstrap_cluster_cidr.split(',')[0] }}"
   SERVICE_CIDR: "{{ bootstrap_service_cidr.split(',')[0] }}"
-  NODE_CIDR: "{{ bootstrap_node_cidr }}"
+  NODE_CIDR: "{{ bootstrap_node_cidr.split(',')[0] }}"
   {% if bootstrap_ipv6_enabled | default(false) %}
+  NODE_CIDR_V6: "{{ bootstrap_node_cidr.split(',')[1] }}"
   CLUSTER_CIDR_V6: "{{ bootstrap_cluster_cidr.split(',')[1] }}"
   SERVICE_CIDR_V6: "{{ bootstrap_service_cidr.split(',')[1] }}"
   {% endif %}


### PR DESCRIPTION
If the config variable `bootstrap_ipv6_enabled` is set, the CiliumLoadBalancerIPPool is not added to the cluster.

This update changes the bootstrap logic to include a NODE_CIDR_V6 value in the CiliumLoadBalancerIPPool, derived from the key bootstrap_node_cidr in the initial `bootstrap/vars/config.yaml` file.

It's a barebones change - there is no error checking or the like.