### PR TITLE
feat: add renovate regex-manager for bootstrap templates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,8 @@
     ":disableRateLimiting",
     ":dependencyDashboard",
     ":semanticCommits",
-    ":automergeBranch"
+    ":automergeBranch",
+    "github>onedr0p/flux-cluster-template//.github/renovate/bootstrap.json5"
   ],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
@@ -15,26 +16,25 @@
   "schedule": ["on saturday"],
   "flux": {
     "fileMatch": [
-      "(^|/)addons/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
-      "(^|/)ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
-      "(^|/)kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
+      "(^|/)ansible/.+\\.ya?ml$",
+      "(^|/)kubernetes/.+\\.ya?ml$"
     ]
   },
   "helm-values": {
     "fileMatch": [
-      "(^|/)ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
-      "(^|/)kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
+      "(^|/)ansible/.+\\.ya?ml$",
+      "(^|/)kubernetes/.+\\.ya?ml$"
     ]
   },
   "kubernetes": {
     "fileMatch": [
-      "(^|/)ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
-      "(^|/)kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
+      "(^|/)ansible/.+\\.ya?ml$",
+      "(^|/)kubernetes/.+\\.ya?ml$"
     ]
   },
   "kustomize": {
     "fileMatch": [
-      "(^|/)kustomization\\.ya?ml(\\.j2)?(\\.j2)?$"
+      "(^|/)kustomization\\.ya?ml$"
     ]
   },
   // commit message topics
@@ -220,19 +220,23 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Process various other dependencies",
       "fileMatch": [
         "(^|/).taskfiles/.+\\.ya?ml$",
-        "(^|/)ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
-        "(^|/)kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
-        "(^|/)k0s-config.ya?ml(\\.j2)?(\\.j2)?$"
+        "(^|/)ansible/.+\\.ya?ml$",
+        "(^|/)kubernetes/.+\\.ya?ml$",
+        "(^|/)k0s-config.ya?ml$"
       ],
       "matchStrings": [
-        // Example: `k3s_release_version: "v1.27.3+k3s1"`
+        // Example:
+        //   k3s_release_version: "v1.27.3+k3s1"
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?\"(?<currentValue>.*)\"\n",
-        // Example: `- https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml`
+        // Example:
+        //   - https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?-\\s(.*?)\/(?<currentValue>[^/]+)\/[^/]+\n",
-        // Example: apiVersion=helm.cattle.io/v1 kind=HelmChart
+        // Example:
+        //   repo: https://helm.cilium.io
+        //   chart: cilium
+        //   version: 1.14.5
         "datasource=(?<datasource>\\S+)\n.*?repo: (?<registryUrl>\\S+)\n.*?chart: (?<depName>\\S+)\n.*?version: (?<currentValue>\\S+)\n"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",

--- a/.github/renovate/bootstrap.json5
+++ b/.github/renovate/bootstrap.json5
@@ -1,0 +1,54 @@
+{
+  "flux": {
+    "fileMatch": [
+      "(^|/)bootstrap/templates/ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
+      "(^|/)bootstrap/templates/kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
+    ]
+  },
+  "helm-values": {
+    "fileMatch": [
+      "(^|/)bootstrap/templates/ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
+      "(^|/)bootstrap/templates/kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
+    ]
+  },
+  "kubernetes": {
+    "fileMatch": [
+      "(^|/)bootstrap/templates/ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
+      "(^|/)bootstrap/templates/kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
+    ]
+  },
+  "kustomize": {
+    "fileMatch": [
+      "(^|/)bootstrap/templates/kustomization\\.ya?ml(\\.j2)?(\\.j2)?$"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)bootstrap/templates/ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
+        "(^|/)bootstrap/templates/kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
+        "(^|/)bootstrap/templates/k0s-config.ya?ml(\\.j2)?(\\.j2)?$"
+      ],
+      "matchStrings": [
+        // Example:
+        //   chart: cert-manager
+        //   version: v1.13.3
+        "datasource=(?<datasource>\\S+) registryUrl=(?<registryUrl>\\S+)\n.*?chart: (?<depName>\\S+)\n.*?version: (?<currentValue>\\S+)\n",
+        // Example:
+        //   k3s_release_version: "v1.27.3+k3s1"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?\"(?<currentValue>.*)\"\n",
+        // Example:
+        //   - https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?-\\s(.*?)\/(?<currentValue>[^/]+)\/[^/]+\n",
+        // Example:
+        //   repo: https://helm.cilium.io
+        //   chart: cilium
+        //   version: 1.14.5
+        "datasource=(?<datasource>\\S+)\n.*?repo: (?<registryUrl>\\S+)\n.*?chart: (?<depName>\\S+)\n.*?version: (?<currentValue>\\S+)\n"
+      ],
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}

--- a/.taskfiles/Repo/Taskfile.yaml
+++ b/.taskfiles/Repo/Taskfile.yaml
@@ -7,15 +7,16 @@ tasks:
   clean:
     desc: Clean files and directories no longer needed after cluster bootstrap
     cmds:
-      # Clean up CI
+      # Clean CI
       - rm -rf {{.ROOT_DIR}}/.github/tests
       - rm -rf {{.ROOT_DIR}}/.github/workflows/e2e.yaml
+      # Clean renovate
+      - rm -rf {{.ROOT_DIR}}/.github/renovate/bootstrap.json5
+      - sed -i {{if eq OS "darwin"}}''{{end}} '/bootstrap\.json5/d' {{.ROOT_DIR}}/.github/renovate.json5
       # Move bootstrap directory to gitignored directory
       - mkdir -p {{.ROOT_DIR}}/.private
       - mv {{.BOOTSTRAP_DIR}} {{.ROOT_DIR}}/.private/bootstrap-{{now | date "150405"}}
       - mv {{.ROOT_DIR}}/makejinja.toml {{.ROOT_DIR}}/.private/makejinja-{{now | date "150405"}}.toml
-      # Update renovate.json5
-      - sed -i {{if eq OS "darwin"}}''{{end}} 's/(..\.j2)\?(..\.j2)\?//g' {{.ROOT_DIR}}/.github/renovate.json5
     preconditions:
       - { msg: "bootstrap dir not found",  sh: "test -d {{.BOOTSTRAP_DIR}}" }
       - { msg: "renovate.json5 not found", sh: "test -f {{.ROOT_DIR}}/.github/renovate.json5" }

--- a/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://charts.jetstack.io #>
       chart: cert-manager
       version: v1.13.3
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 15m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://bjw-s.github.io/helm-charts #>
       chart: app-template
       version: 2.4.0
       interval: 30m

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://bjw-s.github.io/helm-charts #>
       chart: app-template
       version: 2.4.0
       interval: 30m

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=docker registryUrl=ghcr.io/weaveworks/charts #>
       chart: weave-gitops
       version: 4.0.36
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://helm.cilium.io #>
       chart: cilium
       version: 1.14.5
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://coredns.github.io/helm #>
       chart: coredns
       version: 1.29.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/metrics-server #>
       chart: metrics-server
       version: 3.11.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/network/cloudflared/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/cloudflared/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://bjw-s.github.io/helm-charts #>
       chart: app-template
       version: 2.4.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://bjw-s.github.io/helm-charts #>
       chart: app-template
       version: 2.4.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/network/external-dns/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/external-dns/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/external-dns #>
       chart: external-dns
       version: 1.14.1
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://ori-edge.github.io/k8s_gateway #>
       chart: k8s-gateway
       version: 2.1.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/network/nginx/external/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/external/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://kubernetes.github.io/ingress-nginx #>
       chart: ingress-nginx
       version: 4.7.1
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/network/nginx/internal/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/internal/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://kubernetes.github.io/ingress-nginx #>
       chart: ingress-nginx
       version: 4.7.1
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts #>
       chart: grafana
       version: 7.0.19
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
@@ -9,6 +9,7 @@ spec:
   timeout: 15m
   chart:
     spec:
+      <# renovate: datasource=docker registryUrl=ghcr.io/prometheus-community/charts #>
       chart: kube-prometheus-stack
       version: 55.8.1
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://kubernetes.github.io/dashboard #>
       chart: kubernetes-dashboard
       version: 6.0.8
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts #>
       chart: csi-driver-nfs
       version: v4.5.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/storage/openebs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/openebs/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://openebs.github.io/charts #>
       chart: openebs
       version: 3.10.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://backube.github.io/helm-charts #>
       chart: volsync
       version: 0.8.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/tools/descheduler/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/descheduler/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/descheduler #>
       chart: descheduler
       version: 0.29.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/tools/reloader/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/reloader/app/helmrelease.yaml.j2
@@ -7,6 +7,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://stakater.github.io/stakater-charts #>
       chart: reloader
       version: 1.0.62
       sourceRef:

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/helmrelease.yaml.j2
@@ -8,6 +8,7 @@ spec:
   interval: 30m
   chart:
     spec:
+      <# renovate: datasource=helm registryUrl=https://bjw-s.github.io/helm-charts #>
       chart: app-template
       version: 2.4.0
       sourceRef:

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/backube.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/backube.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://backube.github.io/helm-charts/
+  url: https://backube.github.io/helm-charts

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/k8s-gateway.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/k8s-gateway.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://ori-edge.github.io/k8s_gateway/
+  url: https://ori-edge.github.io/k8s_gateway

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/kubernetes-dashboard.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/kubernetes-dashboard.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://kubernetes.github.io/dashboard/
+  url: https://kubernetes.github.io/dashboard


### PR DESCRIPTION
With adding jinja to pretty much all the Flux HelmReleases Renovate will not parse those files using the builtin managers. After the templates get rendered the old style renovate comment is gone.

See here https://github.com/renovatebot/renovate/discussions/18470