### PR TITLE
feat: change jinja block/start delimiters for renovate support

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,6 @@
   "schedule": ["on saturday"],
   "flux": {
     "fileMatch": [
-      "(^|/)addons/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
       "(^|/)ansible/.+\\.ya?ml(\\.j2)?(\\.j2)?$",
       "(^|/)kubernetes/.+\\.ya?ml(\\.j2)?(\\.j2)?$"
     ]
@@ -228,11 +227,16 @@
         "(^|/)k0s-config.ya?ml(\\.j2)?(\\.j2)?$"
       ],
       "matchStrings": [
-        // Example: `k3s_release_version: "v1.27.3+k3s1"`
+        // Example:
+        //   k3s_release_version: "v1.27.3+k3s1"
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?\"(?<currentValue>.*)\"\n",
-        // Example: `- https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml`
+        // Example:
+        //   - https://github.com/rancher/system-upgrade-controller/releases/download/v0.11.0/crd.yaml
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\n.*?-\\s(.*?)\/(?<currentValue>[^/]+)\/[^/]+\n",
-        // Example: apiVersion=helm.cattle.io/v1 kind=HelmChart
+        // Example:
+        //   repo: https://helm.cilium.io
+        //   chart: cilium
+        //   version: 1.14.5
         "datasource=(?<datasource>\\S+)\n.*?repo: (?<registryUrl>\\S+)\n.*?chart: (?<depName>\\S+)\n.*?version: (?<currentValue>\\S+)\n"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",

--- a/bootstrap/templates/.sops.yaml.j2
+++ b/bootstrap/templates/.sops.yaml.j2
@@ -4,8 +4,8 @@ creation_rules:
     encrypted_regex: "^(data|stringData)$"
     key_groups:
       - age:
-          - "<< bootstrap_age_public_key >>"
+          - "{% bootstrap_age_public_key %}"
   - path_regex: ansible/.*\.sops\.ya?ml
     key_groups:
       - age:
-          - "<< bootstrap_age_public_key >>"
+          - "{% bootstrap_age_public_key %}"

--- a/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 #
 # Below vars are for the xanmanning.k3s role
@@ -9,17 +9,17 @@
 k3s_release_version: "v1.29.0+k3s1"
 k3s_install_hard_links: true
 k3s_become: true
-<% if bootstrap_nodes.master | length > 1 %>
+#% if bootstrap_nodes.master | length > 1 %#
 k3s_etcd_datastore: true
-<% else %>
+#% else %#
 k3s_etcd_datastore: false
-<% endif %>
+#% endif %#
 k3s_registration_address: "{{ kube_api_addr }}"
 # /var/lib/rancher/k3s/server/manifests
 k3s_server_manifests_templates:
   - custom-cilium-helmchart.yaml.j2
   - custom-coredns-helmchart.yaml.j2
-<% if bootstrap_nodes.master | length > 1 and not bootstrap_kube_api_addr %>
+#% if bootstrap_nodes.master | length > 1 and not bootstrap_kube_api_addr %#
 # /var/lib/rancher/k3s/server/manifests
 k3s_server_manifests_urls:
   - url: https://raw.githubusercontent.com/kube-vip/website/main/content/manifests/rbac.yaml
@@ -27,5 +27,5 @@ k3s_server_manifests_urls:
 # /var/lib/rancher/k3s/agent/pod-manifests
 k3s_server_pod_manifests_templates:
   - kube-vip-static-pod.yaml.j2
-<% endif %>
-<% endif %>
+#% endif %#
+#% endif %#

--- a/bootstrap/templates/ansible/inventory/group_vars/kubernetes/supplemental.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/kubernetes/supplemental.yaml.j2
@@ -1,16 +1,16 @@
 ---
-timezone: "<< bootstrap_timezone >>"
-github_username: "<< bootstrap_github_username >>"
-coredns_addr: "<< bootstrap_service_cidr.split(',')[0] | nthhost(10) >>"
-<% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %>
-kube_api_addr: "<< bootstrap_nodes.master[0].address >>"
-<% else %>
-kube_api_addr: "<< bootstrap_kube_api_addr >>"
-<% endif %>
-cluster_cidr: "<< bootstrap_cluster_cidr.split(',')[0] >>"
-service_cidr: "<< bootstrap_service_cidr.split(',')[0] >>"
-node_cidr: "<< bootstrap_node_cidr >>"
-<% if bootstrap_ipv6_enabled | default(false) %>
-cluster_cidr_v6: "<< bootstrap_cluster_cidr.split(',')[1] >>"
-service_cidr_v6: "<< bootstrap_service_cidr.split(',')[1] >>"
-<% endif %>
+timezone: "{% bootstrap_timezone %}"
+github_username: "{% bootstrap_github_username %}"
+coredns_addr: "{% bootstrap_service_cidr.split(',')[0] | nthhost(10) %}"
+#% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %#
+kube_api_addr: "{% bootstrap_nodes.master[0].address %}"
+#% else %#
+kube_api_addr: "{% bootstrap_kube_api_addr %}"
+#% endif %#
+cluster_cidr: "{% bootstrap_cluster_cidr.split(',')[0] %}"
+service_cidr: "{% bootstrap_service_cidr.split(',')[0] %}"
+node_cidr: "{% bootstrap_node_cidr %}"
+#% if bootstrap_ipv6_enabled | default(false) %#
+cluster_cidr_v6: "{% bootstrap_cluster_cidr.split(',')[1] %}"
+service_cidr_v6: "{% bootstrap_service_cidr.split(',')[1] %}"
+#% endif %#

--- a/bootstrap/templates/ansible/inventory/group_vars/master/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/master/main.yaml.j2
@@ -1,15 +1,15 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 # https://rancher.com/docs/k3s/latest/en/installation/install-options/server-config/
 # https://github.com/PyratLabs/ansible-role-k3s
 
 k3s_control_node: true
 k3s_server:
-  <% if bootstrap_ipv6_enabled | default(false) %>
+  #% if bootstrap_ipv6_enabled | default(false) %#
   node-ip: "{{ ansible_host }},{{ ansible_default_ipv6.address }}"
-  <% else %>
+  #% else %#
   node-ip: "{{ ansible_host }}"
-  <% endif %>
+  #% endif %#
   tls-san:
     - "{{ kube_api_addr }}"
   docker: false
@@ -27,13 +27,13 @@ k3s_server:
   write-kubeconfig-mode: "644"
   pause-image: registry.k8s.io/pause:3.9
   secrets-encryption: true
-  <% if bootstrap_ipv6_enabled | default(false) %>
+  #% if bootstrap_ipv6_enabled | default(false) %#
   cluster-cidr: "{{ cluster_cidr }},{{ cluster_cidr_v6 }}"
   service-cidr: "{{ service_cidr }},{{ service_cidr_v6 }}"
-  <% else %>
+  #% else %#
   cluster-cidr: "{{ cluster_cidr }}"
   service-cidr: "{{ service_cidr }}"
-  <% endif %>
+  #% endif %#
   etcd-expose-metrics: true           # Required to monitor etcd with kube-prometheus-stack
   kube-controller-manager-arg:
     - "bind-address=0.0.0.0"          # Required to monitor kube-controller-manager with kube-prometheus-stack
@@ -45,4 +45,4 @@ k3s_server:
   kubelet-arg:
     - "image-gc-high-threshold=55"
     - "image-gc-low-threshold=50"
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/inventory/group_vars/worker/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/worker/main.yaml.j2
@@ -1,18 +1,18 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 # https://rancher.com/docs/k3s/latest/en/installation/install-options/agent-config/
 # https://github.com/PyratLabs/ansible-role-k3s
 
 k3s_control_node: false
 k3s_agent:
-  <% if bootstrap_ipv6_enabled | default(false) %>
+  #% if bootstrap_ipv6_enabled | default(false) %#
   node-ip: "{{ ansible_host }},{{ ansible_default_ipv6.address }}"
-  <% else %>
+  #% else %#
   node-ip: "{{ ansible_host }}"
-  <% endif %>
+  #% endif %#
   pause-image: registry.k8s.io/pause:3.9
   # TODO: Move these options to a kubelet config file
   kubelet-arg:
     - "image-gc-high-threshold=55"
     - "image-gc-low-threshold=50"
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/inventory/hosts.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/hosts.yaml.j2
@@ -3,25 +3,25 @@ kubernetes:
   children:
     master:
       hosts:
-      <% for item in bootstrap_nodes.master %>
-        << item.name >>:
-          ansible_user: << item.username >>
-      <% if item.external_address is defined %>
-          ansible_host: << item.external_address >>
-      <% else %>
-          ansible_host: << item.address >>
-      <% endif %>
-      <% endfor %>
-    <% if bootstrap_nodes.worker | default([]) | length > 0 %>
+      #% for item in bootstrap_nodes.master %#
+        "{% item.name %}":
+          ansible_user: "{% item.username %}"
+      #% if item.external_address is defined %#
+          ansible_host: "{% item.external_address %}"
+      #% else %#
+          ansible_host: "{% item.address %}"
+      #% endif %#
+      #% endfor %#
+    #% if bootstrap_nodes.worker | default([]) | length > 0 %#
     worker:
       hosts:
-      <% for item in bootstrap_nodes.worker %>
-        << item.name >>:
-          ansible_user: << item.username >>
-      <% if item.external_address is defined %>
-          ansible_host: << item.external_address >>
-      <% else %>
-          ansible_host: << item.address >>
-      <% endif %>
-      <% endfor %>
-    <% endif %>
+      #% for item in bootstrap_nodes.worker %#
+        "{% item.name %}":
+          ansible_user: "{% item.username %}"
+      #% if item.external_address is defined %#
+          ansible_host: "{% item.external_address %}"
+      #% else %#
+          ansible_host: "{% item.address %}"
+      #% endif %#
+      #% endfor %#
+    #% endif %#

--- a/bootstrap/templates/ansible/playbooks/cluster-installation.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-installation.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 - name: Cluster Installation
   hosts: kubernetes
@@ -60,4 +60,4 @@
     - name: Cruft
       when: k3s_primary_control_node
       ansible.builtin.include_tasks: tasks/cruft.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/cluster-kube-vip.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-kube-vip.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 - name: Cluster kube-vip
   hosts: master
@@ -23,4 +23,4 @@
         src: templates/kube-vip-static-pod.yaml.j2
         dest: "{{ k3s_server_pod_manifests_dir }}/kube-vip-static-pod.yaml"
         mode: preserve
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
@@ -21,7 +21,7 @@
       ansible.builtin.pause:
         seconds: 5
   tasks:
-    <% if bootstrap_distribution == "k3s" %>
+    #% if bootstrap_distribution == "k3s" %#
     - name: Stop Kubernetes # noqa: ignore-errors
       ignore_errors: true
       block:
@@ -31,7 +31,7 @@
             public: true
           vars:
             k3s_state: stopped
-    <% endif %>
+    #% endif %#
 
     # https://github.com/k3s-io/docs/blob/main/docs/installation/network-options.md
     - name: Networking
@@ -57,7 +57,7 @@
             path: /etc/cni/net.d
             state: absent
 
-    <% if bootstrap_distribution == "k3s" %>
+    #% if bootstrap_distribution == "k3s" %#
     - name: Check to see if k3s-killall.sh exits
       ansible.builtin.stat:
         path: /usr/local/bin/k3s-killall.sh
@@ -92,11 +92,11 @@
         path: "{{ k3s_install_dir }}/{{ item }}"
         state: absent
       loop: ["kubectl", "crictl", "ctr"]
-    <% endif %>
+    #% endif %#
 
     - name: Remove local storage path
       ansible.builtin.file:
-        path: "<< bootstrap_local_storage_path >>"
+        path: "{% bootstrap_local_storage_path %}"
         state: absent
 
     - name: Reboot

--- a/bootstrap/templates/ansible/playbooks/cluster-rollout-update.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-rollout-update.yaml.j2
@@ -12,11 +12,11 @@
         seconds: 5
   tasks:
     - name: Details
-      <% if bootstrap_distribution == 'k3s' %>
+      #% if bootstrap_distribution == 'k3s' %#
       ansible.builtin.command: "k3s kubectl get node {{ inventory_hostname }} -o json"
-      <% elif bootstrap_distribution == 'k0s' %>
+      #% elif bootstrap_distribution == 'k0s' %#
       ansible.builtin.command: "k0s kubectl get node {{ inventory_hostname }} -o json"
-      <% endif %>
+      #% endif %#
       register: kubectl_get_node
       delegate_to: "{{ groups['master'][0] }}"
       failed_when: false
@@ -32,22 +32,22 @@
         - name: Cordon
           kubernetes.core.k8s_drain:
             name: "{{ inventory_hostname }}"
-            <% if bootstrap_distribution == 'k3s' %>
+            #% if bootstrap_distribution == 'k3s' %#
             kubeconfig: /etc/rancher/k3s/k3s.yaml
-            <% elif bootstrap_distribution == 'k0s' %>
+            #% elif bootstrap_distribution == 'k0s' %#
             kubeconfig: /var/lib/k0s/pki/admin.conf
-            <% endif %>
+            #% endif %#
             state: cordon
           delegate_to: "{{ groups['master'][0] }}"
 
         - name: Drain
           kubernetes.core.k8s_drain:
             name: "{{ inventory_hostname }}"
-            <% if bootstrap_distribution == 'k3s' %>
+            #% if bootstrap_distribution == 'k3s' %#
             kubeconfig: /etc/rancher/k3s/k3s.yaml
-            <% elif bootstrap_distribution == 'k0s' %>
+            #% elif bootstrap_distribution == 'k0s' %#
             kubeconfig: /var/lib/k0s/pki/admin.conf
-            <% endif %>
+            #% endif %#
             state: drain
             delete_options:
               delete_emptydir_data: true
@@ -79,10 +79,10 @@
         - name: Uncordon
           kubernetes.core.k8s_drain:
             name: "{{ inventory_hostname }}"
-            <% if bootstrap_distribution == 'k3s' %>
+            #% if bootstrap_distribution == 'k3s' %#
             kubeconfig: /etc/rancher/k3s/k3s.yaml
-            <% elif bootstrap_distribution == 'k0s' %>
+            #% elif bootstrap_distribution == 'k0s' %#
             kubeconfig: /var/lib/k0s/pki/admin.conf
-            <% endif %>
+            #% endif %#
             state: uncordon
           delegate_to: "{{ groups['master'][0] }}"

--- a/bootstrap/templates/ansible/playbooks/tasks/cilium.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/tasks/cilium.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 - name: Cilium
   block:
@@ -55,4 +55,4 @@
         definition:
           metadata:
             finalizers: []
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/tasks/coredns.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/tasks/coredns.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 - name: Coredns
   block:
@@ -55,4 +55,4 @@
         definition:
           metadata:
             finalizers: []
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/tasks/cruft.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/tasks/cruft.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 # https://github.com/k3s-io/k3s/issues/1971
 - name: Cruft
@@ -31,4 +31,4 @@
         namespace: kube-system
         state: absent
       loop: "{{ addons_list.resources | selectattr('metadata.name', 'match', '^custom-.*') | list }}"
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/tasks/kubeconfig.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/tasks/kubeconfig.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 - name: Get absolute path to this Git repository # noqa: command-instead-of-module
   ansible.builtin.command: git rev-parse --show-toplevel
@@ -25,4 +25,4 @@
     path: "{{ repository_path.stdout }}/kubeconfig"
     regexp: https://127.0.0.1:6443
     replace: "https://{{ k3s_registration_address }}:6443"
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2.j2
+++ b/bootstrap/templates/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 # https://docs.k3s.io/helm
 apiVersion: helm.cattle.io/v1
@@ -32,28 +32,28 @@ spec:
     ipam:
       mode: kubernetes
     ipv4NativeRoutingCIDR: "{{ cluster_cidr }}"
-    <% if bootstrap_ipv6_enabled | default(false) %>
+    #% if bootstrap_ipv6_enabled | default(false) %#
     ipv6NativeRoutingCIDR: "{{ cluster_cidr_v6 }}"
     ipv6:
       enabled: true
-    <% endif %>
+    #% endif %#
     k8sServiceHost: "{{ kube_api_addr }}"
     k8sServicePort: 6443
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
-      <% if bootstrap_ipv6_enabled | default(false) %>
+      #% if bootstrap_ipv6_enabled | default(false) %#
       enabled: false
-      <% else %>
+      #% else %#
       enabled: true
       # https://github.com/cilium/cilium/issues/26586
       leaseDuration: 120s
       leaseRenewDeadline: 60s
       leaseRetryPeriod: 1s
-      <% endif %>
+      #% endif %#
     loadBalancer:
       algorithm: maglev
-      mode: << bootstrap_cilium_loadbalancer_mode | default('dsr', true) >>
+      mode: "{% bootstrap_cilium_loadbalancer_mode | default('dsr', true) %}"
     localRedirectPolicy: true
     operator:
       replicas: 1
@@ -62,4 +62,4 @@ spec:
     routingMode: native
     securityContext:
       privileged: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/templates/custom-coredns-helmchart.yaml.j2.j2
+++ b/bootstrap/templates/ansible/playbooks/templates/custom-coredns-helmchart.yaml.j2.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' %>
+#% if bootstrap_distribution == 'k3s' %#
 ---
 # https://docs.k3s.io/helm
 apiVersion: helm.cattle.io/v1
@@ -76,4 +76,4 @@ spec:
         labelSelector:
           matchLabels:
             app.kubernetes.io/instance: coredns
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/ansible/playbooks/templates/kube-vip-static-pod.yaml.j2.j2
+++ b/bootstrap/templates/ansible/playbooks/templates/kube-vip-static-pod.yaml.j2.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k3s' and bootstrap_nodes.master | length > 1 and not bootstrap_kube_api_addr %>
+#% if bootstrap_distribution == 'k3s' and bootstrap_nodes.master | length > 1 and not bootstrap_kube_api_addr %#
 ---
 apiVersion: v1
 kind: Pod
@@ -58,4 +58,4 @@ spec:
     - name: kubeconfig
       hostPath:
         path: /etc/rancher/k3s/k3s.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/k0s-config.yaml.j2
+++ b/bootstrap/templates/k0s-config.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == 'k0s' %>
+#% if bootstrap_distribution == 'k0s' %#
 ---
 apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: Cluster
@@ -6,25 +6,25 @@ metadata:
   name: k0s-cluster
 spec:
   hosts:
-    <% for item in bootstrap_nodes.master %>
-    - role: << item.role | default('controller+worker') >>
+    #% for item in bootstrap_nodes.master %#
+    - role: "{% item.role | default('controller+worker') %}"
       ssh:
-        address: << item.address >>
-        user: << item.username >>
+        address: "{% item.address %}"
+        user: "{% item.username %}"
       installFlags:
         - --disable-components=metrics-server
-        <% if item.role | default('') == 'controller+worker' %>
+        #% if item.role | default('') == 'controller+worker' %#
         - --no-taints
-        <% endif %>
-    <% endfor %>
-    <% if bootstrap_nodes.worker | default([]) | length > 0 %>
-    <% for item in bootstrap_nodes.worker %>
+        #% endif %#
+    #% endfor %#
+    #% if bootstrap_nodes.worker | default([]) | length > 0 %#
+    #% for item in bootstrap_nodes.worker %#
     - role: worker
       ssh:
-        address: << item.address >>
-        user: << item.username >>
-    <% endfor %>
-    <% endif %>
+        address: "{% item.address %}"
+        user: "{% item.username %}"
+    #% endfor %#
+    #% endif %#
   k0s:
     # renovate: datasource=github-releases depName=k0sproject/k0s
     version: "v1.28.5+k0s.0"
@@ -43,18 +43,18 @@ spec:
             bind-address: "0.0.0.0"
         api:
           sans:
-            - << bootstrap_kube_api_addr >>
-            <% if bootstrap_kubeapi_hostname is defined %>
-            - << bootstrap_kubeapi_hostname >>
-            <% endif %>
-            <% for item in bootstrap_nodes.master %>
-            <% if item.address != bootstrap_kube_api_addr %>
-            - << item.address >>
-            <% endif %>
-            <% if (bootstrap_kubeapi_hostname is not defined) or (item.name != bootstrap_kubeapi_hostname) %>
-            - << item.name >>
-            <% endif %>
-            <% endfor %>
+            - "{% bootstrap_kube_api_addr %}"
+            #% if bootstrap_kubeapi_hostname is defined %#
+            - "{% bootstrap_kubeapi_hostname %}"
+            #% endif %#
+            #% for item in bootstrap_nodes.master %#
+            #% if item.address != bootstrap_kube_api_addr %#
+            - "{% item.address %}"
+            #% endif %#
+            #% if (bootstrap_kubeapi_hostname is not defined) or (item.name != bootstrap_kubeapi_hostname) %#
+            - "{% item.name %}"
+            #% endif %#
+            #% endfor %#
         extensions:
           helm:
             repositories:
@@ -84,33 +84,33 @@ spec:
                     enabled: false
                   ipam:
                     mode: kubernetes
-                  ipv4NativeRoutingCIDR: "<< bootstrap_cluster_cidr >>"
-                  <% if bootstrap_ipv6_enabled | default(false) %>
-                  ipv6NativeRoutingCIDR: "<< bootstrap_cluster_cidr_v6 >>"
+                  ipv4NativeRoutingCIDR: "{% bootstrap_cluster_cidr %}"
+                  #% if bootstrap_ipv6_enabled | default(false) %#
+                  ipv6NativeRoutingCIDR: "{% bootstrap_cluster_cidr_v6 %}"
                   ipv6:
                     enabled: true
-                  <% endif %>
-                  <% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %>
-                  k8sServiceHost: << bootstrap_nodes.master[0].address >>
-                  <% else %>
-                  k8sServiceHost: << bootstrap_kube_api_addr >>
-                  <% endif %>
+                  #% endif %#
+                  #% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %#
+                  k8sServiceHost: "{% bootstrap_nodes.master[0].address %}"
+                  #% else %#
+                  k8sServiceHost: "{% bootstrap_kube_api_addr %}"
+                  #% endif %#
                   k8sServicePort: 6443
                   kubeProxyReplacement: true
                   kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
                   l2announcements:
-                    <% if bootstrap_ipv6_enabled | default(false) %>
+                    #% if bootstrap_ipv6_enabled | default(false) %#
                     enabled: false
-                    <% else %>
+                    #% else %#
                     enabled: true
                     # https://github.com/cilium/cilium/issues/26586
                     leaseDuration: 120s
                     leaseRenewDeadline: 60s
                     leaseRetryPeriod: 1s
-                    <% endif %>
+                    #% endif %#
                   loadBalancer:
                     algorithm: maglev
-                    mode: << bootstrap_cilium_loadbalancer_mode | default('dsr', true) >>
+                    mode: "{% bootstrap_cilium_loadbalancer_mode | default('dsr', true) %}"
                   localRedirectPolicy: true
                   operator:
                     replicas: 1
@@ -122,10 +122,10 @@ spec:
         network:
           kubeProxy:
             disabled: true
-          <%  if bootstrap_nodes.master | length > 1 %>
+          #%  if bootstrap_nodes.master | length > 1 %#
           nodeLocalLoadBalancing:
             enabled: true
             type: EnvoyProxy
-          <% endif %>
+          #% endif %#
           provider: custom
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/issuers/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/issuers/secret.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: cert-manager-secret
 stringData:
-  api-token: "<< bootstrap_cloudflare_token >>"
+  api-token: "{% bootstrap_cloudflare_token %}"

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if discord_template_notifier.enabled | default(false) %>
+#% if discord_template_notifier.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -62,4 +62,4 @@ spec:
           - path: /data/config.toml
             subPath: config.toml
             readOnly: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if discord_template_notifier.enabled | default(false) %>
+#% if discord_template_notifier.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-<% if discord_template_notifier.enabled | default(false) %>
+#% if discord_template_notifier.enabled | default(false) %#
 ---
 apiVersion: v1
 kind: Secret
@@ -12,5 +12,5 @@ stringData:
     interval = "10m"
     retry_limit = 5
     sink.type = "discord"
-    sink.url = "<< discord_template_notifier.webhook_url >>"
-<% endif %>
+    sink.url = "{% discord_template_notifier.webhook_url %}"
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if discord_template_notifier.enabled | default(false) %>
+#% if discord_template_notifier.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/configmap.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/configmap.yaml.j2
@@ -1,4 +1,4 @@
-<% if homepage.enabled | default(false) %>
+#% if homepage.enabled | default(false) %#
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -76,4 +76,4 @@ data:
           dateStyle: long
           timeStyle: short
           hourCycle: h23
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if homepage.enabled | default(false) %>
+#% if homepage.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -87,4 +87,4 @@ spec:
             path: /app/config/widgets.yaml
     serviceAccount:
       create: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-<% if homepage.enabled | default(false) %>
+#% if homepage.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -6,4 +6,4 @@ resources:
   - ./configmap.yaml
   - ./helmrelease.yaml
   - ./secret.sops.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/secret.sops.yaml.j2
@@ -1,13 +1,13 @@
-<% if homepage.enabled | default(false) %>
+#% if homepage.enabled | default(false) %#
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: homepage-secret
 stringData:
-  HOMEPAGE_VAR_CLOUDFLARED_ACCOUNTID: "<< bootstrap_cloudflare_account_tag >>"
-  HOMEPAGE_VAR_CLOUDFLARED_TUNNELID: "<< bootstrap_cloudflare_tunnel_id >>"
-  HOMEPAGE_VAR_CLOUDFLARED_API_TOKEN: "<< bootstrap_cloudflare_token >>"
+  HOMEPAGE_VAR_CLOUDFLARED_ACCOUNTID: "{% bootstrap_cloudflare_account_tag %}"
+  HOMEPAGE_VAR_CLOUDFLARED_TUNNELID: "{% bootstrap_cloudflare_tunnel_id %}"
+  HOMEPAGE_VAR_CLOUDFLARED_API_TOKEN: "{% bootstrap_cloudflare_token %}"
   HOMEPAGE_VAR_GRAFANA_USERNAME: admin
-  HOMEPAGE_VAR_GRAFANA_PASSWORD: "<< grafana.password >>"
-<% endif %>
+  HOMEPAGE_VAR_GRAFANA_PASSWORD: "{% grafana.password %}"
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/homepage/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if homepage.enabled | default(false) %>
+#% if homepage.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/kustomization.yaml.j2
@@ -3,9 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  <% if homepage.enabled | default(false) %>
+  #% if homepage.enabled | default(false) %#
   - ./homepage/ks.yaml
-  <% endif %>
-  <% if discord_template_notifier.enabled | default(false) %>
+  #% endif %#
+  #% if discord_template_notifier.enabled | default(false) %#
   - ./discord-template-notifier/ks.yaml
-  <% endif %>
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/addons/webhooks/github/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/addons/webhooks/github/secret.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: github-webhook-token-secret
 stringData:
-  token: "<< bootstrap_flux_github_webhook_token >>"
+  token: "{% bootstrap_flux_github_webhook_token %}"

--- a/bootstrap/templates/kubernetes/apps/flux-system/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/kustomization.yaml.j2
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./addons/ks.yaml
-  <% if weave_gitops.enabled | default(false) %>
+  #% if weave_gitops.enabled | default(false) %#
   - ./weave-gitops/ks.yaml
-  <% endif %>
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if weave_gitops.enabled | default(false) %>
+#% if weave_gitops.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -32,13 +32,13 @@ spec:
     ingress:
       enabled: true
       className: internal
-      <% if homepage.enabled | default(false) %>
+      #% if homepage.enabled | default(false) %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/group: Home
         gethomepage.dev/name: Weave-gitops
         gethomepage.dev/icon: flux-cd.png
-      <% endif %>
+      #% endif %#
       hosts:
         - host: &host "gitops.${SECRET_DOMAIN}"
           paths:
@@ -56,4 +56,4 @@ spec:
       impersonationResourceNames: ["admin"]
     podAnnotations:
       secret.reloader.stakater.com/reload: cluster-user-auth
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if weave_gitops.enabled | default(false) %>
+#% if weave_gitops.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-<% if weave_gitops.enabled | default(false) %>
+#% if weave_gitops.enabled | default(false) %#
 ---
 apiVersion: v1
 kind: Secret
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
   username: admin
-  password: "<< weave_gitops.password | encrypt >>"
-<% endif %>
+  password: "{% weave_gitops.password | encrypt %}"
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if weave_gitops.enabled | default(false) %>
+#% if weave_gitops.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -34,11 +34,11 @@ spec:
       id: 1
     containerRuntime:
       integration: containerd
-      <% if bootstrap_distribution == "k3s" %>
+      #% if bootstrap_distribution == "k3s" %#
       socketPath: /var/run/k3s/containerd/containerd.sock
-      <% else %>
+      #% elif bootstrap_distribution == "k0s" %#
       socketPath: /var/run/k0s/containerd.sock
-      <% endif %>
+      #% endif %#
     endpointRoutes:
       enabled: true
     hubble:
@@ -70,13 +70,13 @@ spec:
         ingress:
           enabled: true
           className: internal
-          <% if homepage.enabled | default(false) %>
+          #% if homepage.enabled | default(false) %#
           annotations:
             gethomepage.dev/enabled: "true"
             gethomepage.dev/group: Network
             gethomepage.dev/name: Cilium
             gethomepage.dev/icon: cilium.png
-          <% endif %>
+          #% endif %#
           hosts:
             - "hubble.${SECRET_DOMAIN}"
           tls:
@@ -85,28 +85,28 @@ spec:
     ipam:
       mode: kubernetes
     ipv4NativeRoutingCIDR: "${CLUSTER_CIDR}"
-    <% if bootstrap_ipv6_enabled | default(false) %>
+    #% if bootstrap_ipv6_enabled | default(false) %#
     ipv6NativeRoutingCIDR: "${CLUSTER_CIDR_V6}"
     ipv6:
       enabled: true
-    <% endif %>
+    #% endif %#
     k8sServiceHost: "${KUBE_API_ADDR}"
     k8sServicePort: 6443
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
-      <% if bootstrap_ipv6_enabled | default(false) %>
+      #% if bootstrap_ipv6_enabled | default(false) %#
       enabled: false
-      <% else %>
+      #% else %#
       enabled: true
       # https://github.com/cilium/cilium/issues/26586
       leaseDuration: 120s
       leaseRenewDeadline: 60s
       leaseRetryPeriod: 1s
-      <% endif %>
+      #% endif %#
     loadBalancer:
       algorithm: maglev
-      mode: << bootstrap_cilium_loadbalancer_mode | default('dsr', true) >>
+      mode: "{% bootstrap_cilium_loadbalancer_mode | default('dsr', true) %}"
     localRedirectPolicy: true
     operator:
       replicas: 1

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  <% if not bootstrap_ipv6_enabled | default(false) %>
+  #% if not bootstrap_ipv6_enabled | default(false) %#
   - ./cilium-l2.yaml
-  <% endif %>
+  #% endif %#
   - ./helmrelease.yaml

--- a/bootstrap/templates/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" %>
+#% if bootstrap_distribution == "k3s" %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -87,4 +87,4 @@ spec:
         labelSelector:
           matchLabels:
             app.kubernetes.io/instance: coredns
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/coredns/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/coredns/app/kustomization.yaml.j2
@@ -1,7 +1,7 @@
-<% if bootstrap_distribution == "k3s" %>
+#% if bootstrap_distribution == "k3s" %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/coredns/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/coredns/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" %>
+#% if bootstrap_distribution == "k3s" %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/kustomization.yaml.j2
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./cilium/ks.yaml
-  <% if bootstrap_distribution == "k3s" %>
+  #% if bootstrap_distribution == "k3s" %#
   - ./coredns/ks.yaml
-  <% endif %>
+  #% endif %#
   - ./metrics-server/ks.yaml

--- a/bootstrap/templates/kubernetes/apps/network/cloudflared/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/cloudflared/app/secret.sops.yaml.j2
@@ -4,10 +4,10 @@ kind: Secret
 metadata:
   name: cloudflared-secret
 stringData:
-  TUNNEL_ID: "<< bootstrap_cloudflare_tunnel_id >>"
+  TUNNEL_ID: "{% bootstrap_cloudflare_tunnel_id %}"
   credentials.json: |
     {
-      "AccountTag": "<< bootstrap_cloudflare_account_tag >>",
-      "TunnelSecret": "<< bootstrap_cloudflare_tunnel_secret >>",
-      "TunnelID": "<< bootstrap_cloudflare_tunnel_id >>"
+      "AccountTag": "{% bootstrap_cloudflare_account_tag %}",
+      "TunnelSecret": "{% bootstrap_cloudflare_tunnel_secret %}",
+      "TunnelID": "{% bootstrap_cloudflare_tunnel_id %}"
     }

--- a/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
@@ -71,12 +71,12 @@ spec:
         className: external
         annotations:
           external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
-          <% if homepage.enabled | default(false) %>
+          #% if homepage.enabled | default(false) %#
           gethomepage.dev/enabled: "true"
           gethomepage.dev/group: Network
           gethomepage.dev/name: Echo Server
           gethomepage.dev/icon: mdi-video-input-antenna
-          <% endif %>
+          #% endif %#
         hosts:
           - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
             paths:

--- a/bootstrap/templates/kubernetes/apps/network/external-dns/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/external-dns/app/secret.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: external-dns-secret
 stringData:
-  api-token: "<< bootstrap_cloudflare_token >>"
+  api-token: "{% bootstrap_cloudflare_token %}"

--- a/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
@@ -31,5 +31,5 @@ spec:
       type: LoadBalancer
       port: 53
       annotations:
-        io.cilium/lb-ipam-ips: "<< bootstrap_k8s_gateway_addr >>"
+        io.cilium/lb-ipam-ips: "{% bootstrap_k8s_gateway_addr %}"
       externalTrafficPolicy: Cluster

--- a/bootstrap/templates/kubernetes/apps/network/nginx/certificates/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/certificates/kustomization.yaml.j2
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./staging.yaml
-  <% if bootstrap_acme_production_enabled | default(false) %>
+  #% if bootstrap_acme_production_enabled | default(false) %#
   - ./production.yaml
-  <% endif %>
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/network/nginx/external/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/external/helmrelease.yaml.j2
@@ -33,7 +33,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "<< bootstrap_external_ingress_addr >>"
+          io.cilium/lb-ipam-ips: "{% bootstrap_external_ingress_addr %}"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: external
@@ -71,11 +71,11 @@ spec:
           namespaceSelector:
             any: true
       extraArgs:
-        <% if bootstrap_acme_production_enabled | default(false) %>
+        #% if bootstrap_acme_production_enabled | default(false) %#
         default-ssl-certificate: "network/${SECRET_DOMAIN/./-}-production-tls"
-        <% else %>
+        #% else %#
         default-ssl-certificate: "network/${SECRET_DOMAIN/./-}-staging-tls"
-        <% endif %>
+        #% endif %#
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/bootstrap/templates/kubernetes/apps/network/nginx/internal/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/internal/helmrelease.yaml.j2
@@ -31,7 +31,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "internal.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "<< bootstrap_internal_ingress_addr >>"
+          io.cilium/lb-ipam-ips: "{% bootstrap_internal_ingress_addr %}"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: internal
@@ -69,11 +69,11 @@ spec:
           namespaceSelector:
             any: true
       extraArgs:
-        <% if bootstrap_acme_production_enabled | default(false) %>
+        #% if bootstrap_acme_production_enabled | default(false) %#
         default-ssl-certificate: "network/${SECRET_DOMAIN/./-}-production-tls"
-        <% else %>
+        #% else %#
         default-ssl-certificate: "network/${SECRET_DOMAIN/./-}-staging-tls"
-        <% endif %>
+        #% endif %#
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if grafana.enabled | default(false) %>
+#% if grafana.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -160,7 +160,7 @@ spec:
     ingress:
       enabled: true
       ingressClassName: internal
-      <% if homepage.enabled | default(false) %>
+      #% if homepage.enabled | default(false) %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/icon: grafana.png
@@ -170,7 +170,7 @@ spec:
         gethomepage.dev/widget.url: http://grafana.observability
         gethomepage.dev/widget.username: "{{`{{HOMEPAGE_VAR_GRAFANA_USERNAME}}`}}"
         gethomepage.dev/widget.password: "{{`{{HOMEPAGE_VAR_GRAFANA_PASSWORD}}`}}"
-      <% endif %>
+      #% endif %#
       hosts:
         - &host "grafana.${SECRET_DOMAIN}"
       tls:
@@ -181,4 +181,4 @@ spec:
       storageClassName: openebs-hostpath
     testFramework:
       enabled: false
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if grafana.enabled | default(false) %>
+#% if grafana.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-<% if grafana.enabled | default(false) %>
+#% if grafana.enabled | default(false) %#
 ---
 apiVersion: v1
 kind: Secret
@@ -6,5 +6,5 @@ metadata:
   name: grafana-admin-secret
 stringData:
   admin-user: admin
-  admin-password: "<< grafana.password >>"
-<% endif %>
+  admin-password: "{% grafana.password %}"
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if grafana.enabled | default(false) %>
+#% if grafana.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if kube_prometheus_stack.enabled | default(false) %>
+#% if kube_prometheus_stack.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -54,7 +54,7 @@ spec:
       enabled: true
       serviceMonitor:
         metricRelabelings:
-          <% if bootstrap_distribution == 'k3s' %>
+          #% if bootstrap_distribution == 'k3s' %#
           # Remove duplicate labels provided by k3s
           - action: keep
             sourceLabels: ["__name__"]
@@ -62,7 +62,7 @@ spec:
           - action: replace
             sourceLabels: ["node"]
             targetLabel: instance
-          <% endif %>
+          #% endif %#
           # Drop high cardinality labels
           - action: labeldrop
             regex: (uid)
@@ -75,12 +75,12 @@ spec:
       enabled: true
       serviceMonitor:
         metricRelabelings:
-          <% if bootstrap_distribution == 'k3s' %>
+          #% if bootstrap_distribution == 'k3s' %#
           # Remove duplicate labels provided by k3s
           - action: keep
             sourceLabels: ["__name__"]
             regex: (aggregator_openapi|aggregator_unavailable|apiextensions_openapi|apiserver_admission|apiserver_audit|apiserver_cache|apiserver_cel|apiserver_client|apiserver_crd|apiserver_current|apiserver_envelope|apiserver_flowcontrol|apiserver_init|apiserver_kube|apiserver_longrunning|apiserver_request|apiserver_requested|apiserver_response|apiserver_selfrequest|apiserver_storage|apiserver_terminated|apiserver_tls|apiserver_watch|apiserver_webhooks|authenticated_user|authentication|disabled_metric|etcd_bookmark|etcd_lease|etcd_request|field_validation|get_token|go|grpc_client|hidden_metric|kube_apiserver|kubernetes_build|kubernetes_feature|node_authorizer|pod_security|process_cpu|process_max|process_open|process_resident|process_start|process_virtual|registered_metric|rest_client|scrape_duration|scrape_samples|scrape_series|serviceaccount_legacy|serviceaccount_stale|serviceaccount_valid|watch_cache|workqueue)_(.+)
-          <% endif %>
+          #% endif %#
           # Drop high cardinality labels
           - action: drop
             sourceLabels: ["__name__"]
@@ -91,49 +91,49 @@ spec:
     kubeControllerManager:
       enabled: true
       endpoints: &endpoints
-      <% for item in bootstrap_nodes.master %>
-        - << item.address >>
-      <% endfor %>
-      <% if bootstrap_distribution == 'k3s' %>
+      #% for item in bootstrap_nodes.master %#
+        - "{% item.address %}"
+      #% endfor %#
+      #% if bootstrap_distribution == 'k3s' %#
       serviceMonitor:
         metricRelabelings:
           # Remove duplicate labels provided by k3s
           - action: keep
             sourceLabels: ["__name__"]
             regex: "(apiserver_audit|apiserver_client|apiserver_delegated|apiserver_envelope|apiserver_storage|apiserver_webhooks|attachdetach_controller|authenticated_user|authentication|cronjob_controller|disabled_metric|endpoint_slice|ephemeral_volume|garbagecollector_controller|get_token|go|hidden_metric|job_controller|kubernetes_build|kubernetes_feature|leader_election|node_collector|node_ipam|process_cpu|process_max|process_open|process_resident|process_start|process_virtual|pv_collector|registered_metric|replicaset_controller|rest_client|retroactive_storageclass|root_ca|running_managed|scrape_duration|scrape_samples|scrape_series|service_controller|storage_count|storage_operation|ttl_after|volume_operation|workqueue)_(.+)"
-      <% endif %>
+      #% endif %#
     kubeEtcd:
-      <% if bootstrap_nodes.master | length > 1 %>
+      #% if bootstrap_nodes.master | length > 1 %#
       enabled: true
-      <% else %>
+      #% else %#
       enabled: false
-      <% endif %>
+      #% endif %#
       endpoints: *endpoints
     kubeScheduler:
       enabled: true
       endpoints: *endpoints
-      <% if bootstrap_distribution == 'k3s' %>
+      #% if bootstrap_distribution == 'k3s' %#
       serviceMonitor:
         metricRelabelings:
           # Remove duplicate labels provided by k3s
           - action: keep
             sourceLabels: ["__name__"]
             regex: "(apiserver_audit|apiserver_client|apiserver_delegated|apiserver_envelope|apiserver_storage|apiserver_webhooks|authenticated_user|authentication|disabled_metric|go|hidden_metric|kubernetes_build|kubernetes_feature|leader_election|process_cpu|process_max|process_open|process_resident|process_start|process_virtual|registered_metric|rest_client|scheduler|scrape_duration|scrape_samples|scrape_series|workqueue)_(.+)"
-      <% endif %>
+      #% endif %#
     kubeProxy:
       enabled: false # Disabled due to eBPF
     prometheus:
       ingress:
         enabled: true
         ingressClassName: internal
-        <% if homepage.enabled | default(false) %>
+        #% if homepage.enabled | default(false) %#
         annotations:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/icon: prometheus.png
           gethomepage.dev/name: Prometheus
           gethomepage.dev/group: Observability
           gethomepage.dev/widget.type: prometheus
-        <% endif %>
+        #% endif %#
         pathType: Prefix
         hosts:
           - "prometheus.${SECRET_DOMAIN}"
@@ -164,4 +164,4 @@ spec:
           multicluster:
             etcd:
               enabled: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml.j2
@@ -1,7 +1,7 @@
-<% if kube_prometheus_stack.enabled | default(false) %>
+#% if kube_prometheus_stack.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if kube_prometheus_stack.enabled | default(false) %>
+#% if kube_prometheus_stack.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if kubernetes_dashboard.enabled | default(false) %>
+#% if kubernetes_dashboard.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -32,13 +32,13 @@ spec:
     ingress:
       enabled: true
       className: internal
-      <% if homepage.enabled | default(false) %>
+      #% if homepage.enabled | default(false) %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/icon: kubernetes-dashboard.png
         gethomepage.dev/name: Kubernetes Dashboard
         gethomepage.dev/group: Observability
-      <% endif %>
+      #% endif %#
       hosts:
         - &host "kubernetes.${SECRET_DOMAIN}"
       tls:
@@ -46,4 +46,4 @@ spec:
             - *host
     metricsScraper:
       enabled: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if kubernetes_dashboard.enabled | default(false) %>
+#% if kubernetes_dashboard.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./rbac.yaml
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/rbac.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/rbac.yaml.j2
@@ -1,4 +1,4 @@
-<% if kubernetes_dashboard.enabled | default(false) %>
+#% if kubernetes_dashboard.enabled | default(false) %#
 # For dashboard sign in token:
 # kubectl -n observability get secret kubernetes-dashboard -o jsonpath='{.data.token}' | base64 -d
 ---
@@ -38,4 +38,4 @@ subjects:
   - kind: ServiceAccount
     name: kubernetes-dashboard
     namespace: observability
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if kubernetes_dashboard.enabled | default(false) %>
+#% if kubernetes_dashboard.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -22,4 +22,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kustomization.yaml.j2
@@ -3,12 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  <% if grafana.enabled | default(false) %>
+  #% if grafana.enabled | default(false) %#
   - ./grafana/ks.yaml
-  <% endif %>
-  <% if kube_prometheus_stack.enabled | default(false) %>
+  #% endif %#
+  #% if kube_prometheus_stack.enabled | default(false) %#
   - ./kube-prometheus-stack/ks.yaml
-  <% endif %>
-  <% if kubernetes_dashboard.enabled | default(false) %>
+  #% endif %#
+  #% if kubernetes_dashboard.enabled | default(false) %#
   - ./kubernetes-dashboard/ks.yaml
-  <% endif %>
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if csi_driver_nfs.enabled | default(false) %>
+#% if csi_driver_nfs.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -27,4 +27,4 @@ spec:
   values:
     externalSnapshotter:
       enabled: false
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if csi_driver_nfs.enabled | default(false) %>
+#% if csi_driver_nfs.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./storageclass.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/storageclass.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/storageclass.yaml.j2
@@ -1,16 +1,16 @@
-<% if csi_driver_nfs.enabled | default(false) %>
-<% for item in csi_driver_nfs.storage_class %>
+#% if csi_driver_nfs.enabled | default(false) %#
+#% for item in csi_driver_nfs.storage_class %#
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: << item.name >>
+  name: "{% item.name %}"
 provisioner: nfs.csi.k8s.io
 parameters:
-  server: << item.server >>
-  share: << item.share >>
+  server: "{% item.server %}"
+  share: "{% item.share %}"
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions: ["hard", "noatime"]
-<% endfor %>
-<% endif %>
+#% endfor %#
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if csi_driver_nfs.enabled | default(false) %>
+#% if csi_driver_nfs.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -19,4 +19,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/kustomization.yaml.j2
@@ -4,9 +4,9 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./openebs/ks.yaml
-  <% if volsync.enabled | default(false) %>
+  #% if volsync.enabled | default(false) %#
   - ./volsync/ks.yaml
-  <% endif %>
-  <% if csi_driver_nfs.enabled | default(false) %>
+  #% endif %#
+  #% if csi_driver_nfs.enabled | default(false) %#
   - ./csi-driver-nfs/ks.yaml
-  <% endif %>
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/openebs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/openebs/app/helmrelease.yaml.j2
@@ -29,5 +29,5 @@ spec:
         enabled: true
         name: openebs-hostpath
         isDefaultClass: false
-        basePath: "<< bootstrap_local_storage_path >>"
+        basePath: "{% bootstrap_local_storage_path %}"
 

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if volsync.enabled | default(false) %>
+#% if volsync.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -41,4 +41,4 @@ spec:
       tag: *tag
     metrics:
       disableAuth: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if volsync.enabled | default(false) %>
+#% if volsync.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/prometheusrule.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/prometheusrule.yaml.j2
@@ -1,4 +1,4 @@
-<% if volsync.enabled | default(false) %>
+#% if volsync.enabled | default(false) %#
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -22,4 +22,4 @@ spec:
           for: 15m
           labels:
             severity: critical
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if volsync.enabled | default(false) %>
+#% if volsync.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -39,4 +39,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if volsync.enabled | default(false) %>
+#% if volsync.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -32,4 +32,4 @@ spec:
         create: true
     webhook:
       enabled: false
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/kustomization.yaml.j2
@@ -1,7 +1,7 @@
-<% if volsync.enabled | default(false) %>
+#% if volsync.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/kustomization.yaml.j2
@@ -5,6 +5,6 @@ resources:
   - ./namespace.yaml
   - ./descheduler/ks.yaml
   - ./reloader/ks.yaml
-  <% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+  #% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
   - ./system-upgrade-controller/ks.yaml
-  <% endif %>
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -103,4 +103,4 @@ spec:
         globalMounts:
           - path: /etc/ca-certificates
             readOnly: true
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -7,4 +7,4 @@ resources:
   - https://github.com/rancher/system-upgrade-controller/releases/download/v0.13.2/crd.yaml
   - helmrelease.yaml
   - rbac.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/rbac.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/rbac.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -12,4 +12,4 @@ subjects:
   - kind: ServiceAccount
     name: system-upgrade
     namespace: tools
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/ks.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -41,4 +41,4 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/agent.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/agent.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
@@ -17,4 +17,4 @@ spec:
     args: ["prepare", "server"]
   upgrade:
     image: rancher/k3s-upgrade
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/kustomization.yaml.j2
@@ -1,8 +1,8 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./server.yaml
   - ./agent.yaml
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/server.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/server.yaml.j2
@@ -1,4 +1,4 @@
-<% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %>
+#% if bootstrap_distribution == "k3s" and system_upgrade_controller.enabled | default(false) %#
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
@@ -22,4 +22,4 @@ spec:
     - {key: CriticalAddonsOnly, operator: Exists}
   upgrade:
     image: rancher/k3s-upgrade
-<% endif %>
+#% endif %#

--- a/bootstrap/templates/kubernetes/flux/config/cluster.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/config/cluster.yaml.j2
@@ -7,14 +7,14 @@ metadata:
 spec:
   interval: 30m
   ref:
-    branch: << bootstrap_github_repository_branch | default('main', true) >>
-  <% if bootstrap_private_github_repo | default(false) %>
+    branch: "{% bootstrap_github_repository_branch | default('main', true) %}"
+  #% if bootstrap_private_github_repo | default(false) %#
   secretRef:
     name: github-deploy-key
-  url: "ssh://github.com/<< bootstrap_github_username >>/<< bootstrap_github_repository_name >>"
-  <% else %>
-  url: "https://github.com/<< bootstrap_github_username >>/<< bootstrap_github_repository_name >>.git"
-  <% endif %>
+  url: "ssh://github.com/{% bootstrap_github_username %}/{% bootstrap_github_repository_name %}"
+  #% else %#
+  url: "https://github.com/{% bootstrap_github_username %}/{% bootstrap_github_repository_name %}.git"
+  #% endif %#
   ignore: |
     # exclude all
     /*

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/backube.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/backube.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://backube.github.io/helm-charts/
+  url: https://backube.github.io/helm-charts

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/jetstack.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/jetstack.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://charts.jetstack.io/
+  url: https://charts.jetstack.io

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/k8s-gateway.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/k8s-gateway.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://ori-edge.github.io/k8s_gateway/
+  url: https://ori-edge.github.io/k8s_gateway

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/kubernetes-dashboard.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/kubernetes-dashboard.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://kubernetes.github.io/dashboard/
+  url: https://kubernetes.github.io/dashboard

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/piraeus.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/piraeus.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://piraeus.io/helm-charts/
+  url: https://piraeus.io/helm-charts

--- a/bootstrap/templates/kubernetes/flux/vars/cluster-secrets.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/vars/cluster-secrets.sops.yaml.j2
@@ -5,6 +5,6 @@ metadata:
   name: cluster-secrets
   namespace: flux-system
 stringData:
-  SECRET_DOMAIN: "<< bootstrap_cloudflare_domain >>"
-  SECRET_ACME_EMAIL: "<< bootstrap_acme_email >>"
-  SECRET_CLOUDFLARE_TUNNEL_ID: "<< bootstrap_cloudflare_tunnel_id >>"
+  SECRET_DOMAIN: "{% bootstrap_cloudflare_domain %}"
+  SECRET_ACME_EMAIL: "{% bootstrap_acme_email %}"
+  SECRET_CLOUDFLARE_TUNNEL_ID: "{% bootstrap_cloudflare_tunnel_id %}"

--- a/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
@@ -5,17 +5,17 @@ metadata:
   name: cluster-settings
   namespace: flux-system
 data:
-  TIMEZONE: "<< bootstrap_timezone >>"
-  COREDNS_ADDR: "<< bootstrap_service_cidr.split(',')[0] | nthhost(10) >>"
-  <% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %>
-  KUBE_API_ADDR: "<< bootstrap_nodes.master[0].address >>"
-  <% else %>
-  KUBE_API_ADDR: "<< bootstrap_kube_api_addr >>"
-  <% endif %>
-  CLUSTER_CIDR: "<< bootstrap_cluster_cidr.split(',')[0] >>"
-  SERVICE_CIDR: "<< bootstrap_service_cidr.split(',')[0] >>"
-  NODE_CIDR: "<< bootstrap_node_cidr >>"
-  <% if bootstrap_ipv6_enabled | default(false) %>
-  CLUSTER_CIDR_V6: "<< bootstrap_cluster_cidr.split(',')[1] >>"
-  SERVICE_CIDR_V6: "<< bootstrap_service_cidr.split(',')[1] >>"
-  <% endif %>
+  TIMEZONE: "{% bootstrap_timezone %}"
+  COREDNS_ADDR: "{% bootstrap_service_cidr.split(',')[0] | nthhost(10) %}"
+  #% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %#
+  KUBE_API_ADDR: "{% bootstrap_nodes.master[0].address %}"
+  #% else %#
+  KUBE_API_ADDR: "{% bootstrap_kube_api_addr %}"
+  #% endif %#
+  CLUSTER_CIDR: "{% bootstrap_cluster_cidr.split(',')[0] %}"
+  SERVICE_CIDR: "{% bootstrap_service_cidr.split(',')[0] %}"
+  NODE_CIDR: "{% bootstrap_node_cidr %}"
+  #% if bootstrap_ipv6_enabled | default(false) %#
+  CLUSTER_CIDR_V6: "{% bootstrap_cluster_cidr.split(',')[1] %}"
+  SERVICE_CIDR_V6: "{% bootstrap_service_cidr.split(',')[1] %}"
+  #% endif %#

--- a/makejinja.toml
+++ b/makejinja.toml
@@ -6,10 +6,12 @@ import_paths = ["./bootstrap/scripts"]
 loaders = ["loader:Loader"]
 jinja_suffix = ".j2"
 
+# Block delimiters are changed to avoid conflicts with Renovate
+# https://github.com/renovatebot/renovate/discussions/18470
 [makejinja.delimiter]
-block_start = "<%"
-block_end = "%>"
-comment_start = "<#"
-comment_end = "#>"
-variable_start = "<<"
-variable_end = ">>"
+block_start = "#%"
+block_end = "%#"
+comment_start = "{#"
+comment_end = "#}"
+variable_start = "{%"
+variable_end = "%}"


### PR DESCRIPTION
This changes the jinja delimiters so that renovate doesn't choke when parsing these files

- `<% ... %>` -> `#% ... %#`
- `<< ... >>` -> `{% ... %}`