### PR TITLE
feat: change jinja variable start/end delimiters to avoid conflicts with go templating

### DIFF
--- a/bootstrap/templates/.sops.yaml.j2
+++ b/bootstrap/templates/.sops.yaml.j2
@@ -4,8 +4,8 @@ creation_rules:
     encrypted_regex: "^(data|stringData)$"
     key_groups:
       - age:
-          - "{% bootstrap_age_public_key %}"
+          - "#{ bootstrap_age_public_key }#"
   - path_regex: ansible/.*\.sops\.ya?ml
     key_groups:
       - age:
-          - "{% bootstrap_age_public_key %}"
+          - "#{ bootstrap_age_public_key }#"

--- a/bootstrap/templates/ansible/inventory/group_vars/kubernetes/supplemental.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/kubernetes/supplemental.yaml.j2
@@ -1,16 +1,16 @@
 ---
-timezone: "{% bootstrap_timezone %}"
-github_username: "{% bootstrap_github_username %}"
-coredns_addr: "{% bootstrap_service_cidr.split(',')[0] | nthhost(10) %}"
+timezone: "#{ bootstrap_timezone }#"
+github_username: "#{ bootstrap_github_username }#"
+coredns_addr: "#{ bootstrap_service_cidr.split(',')[0] | nthhost(10) }#"
 #% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %#
-kube_api_addr: "{% bootstrap_nodes.master[0].address %}"
+kube_api_addr: "#{ bootstrap_nodes.master[0].address }#"
 #% else %#
-kube_api_addr: "{% bootstrap_kube_api_addr %}"
+kube_api_addr: "#{ bootstrap_kube_api_addr }#"
 #% endif %#
-cluster_cidr: "{% bootstrap_cluster_cidr.split(',')[0] %}"
-service_cidr: "{% bootstrap_service_cidr.split(',')[0] %}"
-node_cidr: "{% bootstrap_node_cidr %}"
+cluster_cidr: "#{ bootstrap_cluster_cidr.split(',')[0] }#"
+service_cidr: "#{ bootstrap_service_cidr.split(',')[0] }#"
+node_cidr: "#{ bootstrap_node_cidr }#"
 #% if bootstrap_ipv6_enabled | default(false) %#
-cluster_cidr_v6: "{% bootstrap_cluster_cidr.split(',')[1] %}"
-service_cidr_v6: "{% bootstrap_service_cidr.split(',')[1] %}"
+cluster_cidr_v6: "#{ bootstrap_cluster_cidr.split(',')[1] }#"
+service_cidr_v6: "#{ bootstrap_service_cidr.split(',')[1] }#"
 #% endif %#

--- a/bootstrap/templates/ansible/inventory/hosts.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/hosts.yaml.j2
@@ -4,24 +4,24 @@ kubernetes:
     master:
       hosts:
       #% for item in bootstrap_nodes.master %#
-        "{% item.name %}":
-          ansible_user: "{% item.username %}"
+        "#{ item.name }#":
+          ansible_user: "#{ item.username }#"
       #% if item.external_address is defined %#
-          ansible_host: "{% item.external_address %}"
+          ansible_host: "#{ item.external_address }#"
       #% else %#
-          ansible_host: "{% item.address %}"
+          ansible_host: "#{ item.address }#"
       #% endif %#
       #% endfor %#
     #% if bootstrap_nodes.worker | default([]) | length > 0 %#
     worker:
       hosts:
       #% for item in bootstrap_nodes.worker %#
-        "{% item.name %}":
-          ansible_user: "{% item.username %}"
+        "#{ item.name }#":
+          ansible_user: "#{ item.username }#"
       #% if item.external_address is defined %#
-          ansible_host: "{% item.external_address %}"
+          ansible_host: "#{ item.external_address }#"
       #% else %#
-          ansible_host: "{% item.address %}"
+          ansible_host: "#{ item.address }#"
       #% endif %#
       #% endfor %#
     #% endif %#

--- a/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
@@ -96,7 +96,7 @@
 
     - name: Remove local storage path
       ansible.builtin.file:
-        path: "{% bootstrap_local_storage_path %}"
+        path: "#{ bootstrap_local_storage_path }#"
         state: absent
 
     - name: Reboot

--- a/bootstrap/templates/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2.j2
+++ b/bootstrap/templates/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2.j2
@@ -53,7 +53,7 @@ spec:
       #% endif %#
     loadBalancer:
       algorithm: maglev
-      mode: "{% bootstrap_cilium_loadbalancer_mode | default('dsr', true) %}"
+      mode: "#{ bootstrap_cilium_loadbalancer_mode | default('dsr', true) }#"
     localRedirectPolicy: true
     operator:
       replicas: 1

--- a/bootstrap/templates/k0s-config.yaml.j2
+++ b/bootstrap/templates/k0s-config.yaml.j2
@@ -7,10 +7,10 @@ metadata:
 spec:
   hosts:
     #% for item in bootstrap_nodes.master %#
-    - role: "{% item.role | default('controller+worker') %}"
+    - role: "#{ item.role | default('controller+worker') }#"
       ssh:
-        address: "{% item.address %}"
-        user: "{% item.username %}"
+        address: "#{ item.address }#"
+        user: "#{ item.username }#"
       installFlags:
         - --disable-components=metrics-server
         #% if item.role | default('') == 'controller+worker' %#
@@ -21,8 +21,8 @@ spec:
     #% for item in bootstrap_nodes.worker %#
     - role: worker
       ssh:
-        address: "{% item.address %}"
-        user: "{% item.username %}"
+        address: "#{ item.address }#"
+        user: "#{ item.username }#"
     #% endfor %#
     #% endif %#
   k0s:
@@ -43,16 +43,16 @@ spec:
             bind-address: "0.0.0.0"
         api:
           sans:
-            - "{% bootstrap_kube_api_addr %}"
+            - "#{ bootstrap_kube_api_addr }#"
             #% if bootstrap_kubeapi_hostname is defined %#
-            - "{% bootstrap_kubeapi_hostname %}"
+            - "#{ bootstrap_kubeapi_hostname }#"
             #% endif %#
             #% for item in bootstrap_nodes.master %#
             #% if item.address != bootstrap_kube_api_addr %#
-            - "{% item.address %}"
+            - "#{ item.address }#"
             #% endif %#
             #% if (bootstrap_kubeapi_hostname is not defined) or (item.name != bootstrap_kubeapi_hostname) %#
-            - "{% item.name %}"
+            - "#{ item.name }#"
             #% endif %#
             #% endfor %#
         extensions:
@@ -84,16 +84,16 @@ spec:
                     enabled: false
                   ipam:
                     mode: kubernetes
-                  ipv4NativeRoutingCIDR: "{% bootstrap_cluster_cidr %}"
+                  ipv4NativeRoutingCIDR: "#{ bootstrap_cluster_cidr }#"
                   #% if bootstrap_ipv6_enabled | default(false) %#
-                  ipv6NativeRoutingCIDR: "{% bootstrap_cluster_cidr_v6 %}"
+                  ipv6NativeRoutingCIDR: "#{ bootstrap_cluster_cidr_v6 }#"
                   ipv6:
                     enabled: true
                   #% endif %#
                   #% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %#
-                  k8sServiceHost: "{% bootstrap_nodes.master[0].address %}"
+                  k8sServiceHost: "#{ bootstrap_nodes.master[0].address }#"
                   #% else %#
-                  k8sServiceHost: "{% bootstrap_kube_api_addr %}"
+                  k8sServiceHost: "#{ bootstrap_kube_api_addr }#"
                   #% endif %#
                   k8sServicePort: 6443
                   kubeProxyReplacement: true
@@ -110,7 +110,7 @@ spec:
                     #% endif %#
                   loadBalancer:
                     algorithm: maglev
-                    mode: "{% bootstrap_cilium_loadbalancer_mode | default('dsr', true) %}"
+                    mode: "#{ bootstrap_cilium_loadbalancer_mode | default('dsr', true) }#"
                   localRedirectPolicy: true
                   operator:
                     replicas: 1

--- a/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/issuers/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/issuers/secret.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: cert-manager-secret
 stringData:
-  api-token: "{% bootstrap_cloudflare_token %}"
+  api-token: "#{ bootstrap_cloudflare_token }#"

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/secret.sops.yaml.j2
@@ -12,5 +12,5 @@ stringData:
     interval = "10m"
     retry_limit = 5
     sink.type = "discord"
-    sink.url = "{% discord_template_notifier.webhook_url %}"
+    sink.url = "#{ discord_template_notifier.webhook_url }#"
 #% endif %#

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/secret.sops.yaml.j2
@@ -5,9 +5,9 @@ kind: Secret
 metadata:
   name: homepage-secret
 stringData:
-  HOMEPAGE_VAR_CLOUDFLARED_ACCOUNTID: "{% bootstrap_cloudflare_account_tag %}"
-  HOMEPAGE_VAR_CLOUDFLARED_TUNNELID: "{% bootstrap_cloudflare_tunnel_id %}"
-  HOMEPAGE_VAR_CLOUDFLARED_API_TOKEN: "{% bootstrap_cloudflare_token %}"
+  HOMEPAGE_VAR_CLOUDFLARED_ACCOUNTID: "#{ bootstrap_cloudflare_account_tag }#"
+  HOMEPAGE_VAR_CLOUDFLARED_TUNNELID: "#{ bootstrap_cloudflare_tunnel_id }#"
+  HOMEPAGE_VAR_CLOUDFLARED_API_TOKEN: "#{ bootstrap_cloudflare_token }#"
   HOMEPAGE_VAR_GRAFANA_USERNAME: admin
-  HOMEPAGE_VAR_GRAFANA_PASSWORD: "{% grafana.password %}"
+  HOMEPAGE_VAR_GRAFANA_PASSWORD: "#{ grafana.password }#"
 #% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/addons/webhooks/github/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/addons/webhooks/github/secret.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: github-webhook-token-secret
 stringData:
-  token: "{% bootstrap_flux_github_webhook_token %}"
+  token: "#{ bootstrap_flux_github_webhook_token }#"

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/secret.sops.yaml.j2
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
   username: admin
-  password: "{% weave_gitops.password | encrypt %}"
+  password: "#{ weave_gitops.password | encrypt }#"
 #% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -106,7 +106,7 @@ spec:
       #% endif %#
     loadBalancer:
       algorithm: maglev
-      mode: "{% bootstrap_cilium_loadbalancer_mode | default('dsr', true) %}"
+      mode: "#{ bootstrap_cilium_loadbalancer_mode | default('dsr', true) }#"
     localRedirectPolicy: true
     operator:
       replicas: 1

--- a/bootstrap/templates/kubernetes/apps/network/cloudflared/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/cloudflared/app/secret.sops.yaml.j2
@@ -4,10 +4,10 @@ kind: Secret
 metadata:
   name: cloudflared-secret
 stringData:
-  TUNNEL_ID: "{% bootstrap_cloudflare_tunnel_id %}"
+  TUNNEL_ID: "#{ bootstrap_cloudflare_tunnel_id }#"
   credentials.json: |
     {
-      "AccountTag": "{% bootstrap_cloudflare_account_tag %}",
-      "TunnelSecret": "{% bootstrap_cloudflare_tunnel_secret %}",
-      "TunnelID": "{% bootstrap_cloudflare_tunnel_id %}"
+      "AccountTag": "#{ bootstrap_cloudflare_account_tag }#",
+      "TunnelSecret": "#{ bootstrap_cloudflare_tunnel_secret }#",
+      "TunnelID": "#{ bootstrap_cloudflare_tunnel_id }#"
     }

--- a/bootstrap/templates/kubernetes/apps/network/external-dns/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/external-dns/app/secret.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: external-dns-secret
 stringData:
-  api-token: "{% bootstrap_cloudflare_token %}"
+  api-token: "#{ bootstrap_cloudflare_token }#"

--- a/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
@@ -31,5 +31,5 @@ spec:
       type: LoadBalancer
       port: 53
       annotations:
-        io.cilium/lb-ipam-ips: "{% bootstrap_k8s_gateway_addr %}"
+        io.cilium/lb-ipam-ips: "#{ bootstrap_k8s_gateway_addr }#"
       externalTrafficPolicy: Cluster

--- a/bootstrap/templates/kubernetes/apps/network/nginx/external/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/external/helmrelease.yaml.j2
@@ -33,7 +33,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "{% bootstrap_external_ingress_addr %}"
+          io.cilium/lb-ipam-ips: "#{ bootstrap_external_ingress_addr }#"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: external

--- a/bootstrap/templates/kubernetes/apps/network/nginx/internal/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/nginx/internal/helmrelease.yaml.j2
@@ -31,7 +31,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "internal.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "{% bootstrap_internal_ingress_addr %}"
+          io.cilium/lb-ipam-ips: "#{ bootstrap_internal_ingress_addr }#"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: internal

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/secret.sops.yaml.j2
@@ -6,5 +6,5 @@ metadata:
   name: grafana-admin-secret
 stringData:
   admin-user: admin
-  admin-password: "{% grafana.password %}"
+  admin-password: "#{ grafana.password }#"
 #% endif %#

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
@@ -92,7 +92,7 @@ spec:
       enabled: true
       endpoints: &endpoints
       #% for item in bootstrap_nodes.master %#
-        - "{% item.address %}"
+        - "#{ item.address }#"
       #% endfor %#
       #% if bootstrap_distribution == 'k3s' %#
       serviceMonitor:

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/storageclass.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/storageclass.yaml.j2
@@ -4,11 +4,11 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: "{% item.name %}"
+  name: "#{ item.name }#"
 provisioner: nfs.csi.k8s.io
 parameters:
-  server: "{% item.server %}"
-  share: "{% item.share %}"
+  server: "#{ item.server }#"
+  share: "#{ item.share }#"
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions: ["hard", "noatime"]

--- a/bootstrap/templates/kubernetes/apps/storage/openebs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/openebs/app/helmrelease.yaml.j2
@@ -29,5 +29,5 @@ spec:
         enabled: true
         name: openebs-hostpath
         isDefaultClass: false
-        basePath: "{% bootstrap_local_storage_path %}"
+        basePath: "#{ bootstrap_local_storage_path }#"
 

--- a/bootstrap/templates/kubernetes/flux/config/cluster.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/config/cluster.yaml.j2
@@ -7,13 +7,13 @@ metadata:
 spec:
   interval: 30m
   ref:
-    branch: "{% bootstrap_github_repository_branch | default('main', true) %}"
+    branch: "#{ bootstrap_github_repository_branch | default('main', true) }#"
   #% if bootstrap_private_github_repo | default(false) %#
   secretRef:
     name: github-deploy-key
-  url: "ssh://github.com/{% bootstrap_github_username %}/{% bootstrap_github_repository_name %}"
+  url: "ssh://github.com/#{ bootstrap_github_username }#/#{ bootstrap_github_repository_name }#"
   #% else %#
-  url: "https://github.com/{% bootstrap_github_username %}/{% bootstrap_github_repository_name %}.git"
+  url: "https://github.com/#{ bootstrap_github_username }#/#{ bootstrap_github_repository_name }#.git"
   #% endif %#
   ignore: |
     # exclude all

--- a/bootstrap/templates/kubernetes/flux/vars/cluster-secrets.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/vars/cluster-secrets.sops.yaml.j2
@@ -5,6 +5,6 @@ metadata:
   name: cluster-secrets
   namespace: flux-system
 stringData:
-  SECRET_DOMAIN: "{% bootstrap_cloudflare_domain %}"
-  SECRET_ACME_EMAIL: "{% bootstrap_acme_email %}"
-  SECRET_CLOUDFLARE_TUNNEL_ID: "{% bootstrap_cloudflare_tunnel_id %}"
+  SECRET_DOMAIN: "#{ bootstrap_cloudflare_domain }#"
+  SECRET_ACME_EMAIL: "#{ bootstrap_acme_email }#"
+  SECRET_CLOUDFLARE_TUNNEL_ID: "#{ bootstrap_cloudflare_tunnel_id }#"

--- a/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
@@ -5,17 +5,17 @@ metadata:
   name: cluster-settings
   namespace: flux-system
 data:
-  TIMEZONE: "{% bootstrap_timezone %}"
-  COREDNS_ADDR: "{% bootstrap_service_cidr.split(',')[0] | nthhost(10) %}"
+  TIMEZONE: "#{ bootstrap_timezone }#"
+  COREDNS_ADDR: "#{ bootstrap_service_cidr.split(',')[0] | nthhost(10) }#"
   #% if bootstrap_nodes.master | length == 1 and not bootstrap_kube_api_addr %#
-  KUBE_API_ADDR: "{% bootstrap_nodes.master[0].address %}"
+  KUBE_API_ADDR: "#{ bootstrap_nodes.master[0].address }#"
   #% else %#
-  KUBE_API_ADDR: "{% bootstrap_kube_api_addr %}"
+  KUBE_API_ADDR: "#{ bootstrap_kube_api_addr }#"
   #% endif %#
-  CLUSTER_CIDR: "{% bootstrap_cluster_cidr.split(',')[0] %}"
-  SERVICE_CIDR: "{% bootstrap_service_cidr.split(',')[0] %}"
-  NODE_CIDR: "{% bootstrap_node_cidr %}"
+  CLUSTER_CIDR: "#{ bootstrap_cluster_cidr.split(',')[0] }#"
+  SERVICE_CIDR: "#{ bootstrap_service_cidr.split(',')[0] }#"
+  NODE_CIDR: "#{ bootstrap_node_cidr }#"
   #% if bootstrap_ipv6_enabled | default(false) %#
-  CLUSTER_CIDR_V6: "{% bootstrap_cluster_cidr.split(',')[1] %}"
-  SERVICE_CIDR_V6: "{% bootstrap_service_cidr.split(',')[1] %}"
+  CLUSTER_CIDR_V6: "#{ bootstrap_cluster_cidr.split(',')[1] }#"
+  SERVICE_CIDR_V6: "#{ bootstrap_service_cidr.split(',')[1] }#"
   #% endif %#

--- a/makejinja.toml
+++ b/makejinja.toml
@@ -6,13 +6,13 @@ import_paths = ["./bootstrap/scripts"]
 loaders = ["loader:Loader"]
 jinja_suffix = ".j2"
 
-[makejinja.delimiter]
 # Block and comment delimiters are changed to avoid conflicts with Renovate
+# Variable delimiters are changed to avoid conflicts with Renovate and Go templates
 # https://github.com/renovatebot/renovate/discussions/18470
+[makejinja.delimiter]
 block_start = "#%"
 block_end = "%#"
 comment_start = "#|"
 comment_end = "|#"
-# Variable delimiters are changed to avoid conflicts with Renovate and Go templates
 variable_start = "#{"
 variable_end = "}#"

--- a/makejinja.toml
+++ b/makejinja.toml
@@ -6,12 +6,13 @@ import_paths = ["./bootstrap/scripts"]
 loaders = ["loader:Loader"]
 jinja_suffix = ".j2"
 
-# Block delimiters are changed to avoid conflicts with Renovate
-# https://github.com/renovatebot/renovate/discussions/18470
 [makejinja.delimiter]
+# Block and comment delimiters are changed to avoid conflicts with Renovate
+# https://github.com/renovatebot/renovate/discussions/18470
 block_start = "#%"
 block_end = "%#"
-comment_start = "{#"
-comment_end = "#}"
-variable_start = "{%"
-variable_end = "%}"
+comment_start = "#|"
+comment_end = "|#"
+# Variable delimiters are changed to avoid conflicts with Go templates
+variable_start = "#{"
+variable_end = "}#"

--- a/makejinja.toml
+++ b/makejinja.toml
@@ -13,6 +13,6 @@ block_start = "#%"
 block_end = "%#"
 comment_start = "#|"
 comment_end = "|#"
-# Variable delimiters are changed to avoid conflicts with Go templates
+# Variable delimiters are changed to avoid conflicts with Renovate and Go templates
 variable_start = "#{"
 variable_end = "}#"


### PR DESCRIPTION
Changes Jinja var start/end delimiters from `{% ... %}` to `#{ ... }#` and comment delimiters to `#| ... |#` for consistency with block delimiters

Hopefully this will be the last change to these delimiters