### PR TITLE
feat: rename addon vars to `addon_` prefix and simplify logic in jinja templates

### DIFF
--- a/.github/tests/addons.yaml
+++ b/.github/tests/addons.yaml
@@ -1,29 +1,30 @@
 ---
-homepage:
+
+addon_homepage:
   enabled: true
 
-grafana:
-  enabled: true
-  password: fake
-
-kube_prometheus_stack:
-  enabled: true
-
-kubernetes_dashboard:
-  enabled: true
-
-weave_gitops:
+addon_grafana:
   enabled: true
   password: fake
 
-csi_driver_nfs:
+addon_kube_prometheus_stack:
+  enabled: true
+
+addon_kubernetes_dashboard:
+  enabled: true
+
+addon_weave_gitops:
+  enabled: true
+  password: fake
+
+addon_csi_driver_nfs:
   enabled: true
   storage_class:
     - name: fake
       server: fake
       share: /fake
 
-csi_driver_smb:
+addon_csi_driver_smb:
   enabled: true
   storage_class:
     - name: fake1
@@ -61,18 +62,18 @@ csi_driver_smb:
       gid: 100
       existing_secret_namespace: fake
 
-system_upgrade_controller:
+addon_system_upgrade_controller:
   enabled: true
 
-discord_template_notifier:
+addon_discord_template_notifier:
   enabled: true
   webhook_url: https://discord.com/api/webhooks/fake/fake
 
-volsync:
+addon_volsync:
   enabled: true
 
-spegel:
+addon_spegel:
   enabled: true
 
-longhorn:
+addon_longhorn:
   enabled: true

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if discord_template_notifier|default({}) and discord_template_notifier.enabled|default(false) %#
+#% if addon_discord_template_notifier.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if discord_template_notifier|default({}) and discord_template_notifier.enabled|default(false) %#
+#% if addon_discord_template_notifier.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-#% if discord_template_notifier|default({}) and discord_template_notifier.enabled|default(false) %#
+#% if addon_discord_template_notifier.enabled %#
 ---
 apiVersion: v1
 kind: Secret

--- a/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/discord-template-notifier/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if discord_template_notifier|default({}) and discord_template_notifier.enabled|default(false) %#
+#% if addon_discord_template_notifier.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/configmap.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/configmap.yaml.j2
@@ -1,4 +1,4 @@
-#% if homepage|default({}) and homepage.enabled|default(false) %#
+#% if addon_homepage.enabled %#
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if homepage|default({}) and homepage.enabled|default(false) %#
+#% if addon_homepage.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if homepage|default({}) and homepage.enabled|default(false) %#
+#% if addon_homepage.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/default/homepage/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-#% if homepage|default({}) and homepage.enabled|default(false) %#
+#% if addon_homepage.enabled %#
 ---
 apiVersion: v1
 kind: Secret

--- a/bootstrap/templates/kubernetes/apps/default/homepage/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/homepage/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if homepage|default({}) and homepage.enabled|default(false) %#
+#% if addon_homepage.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/default/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/default/kustomization.yaml.j2
@@ -3,9 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  #% if homepage|default({}) and homepage.enabled|default(false) %#
+  #% if addon_homepage.enabled %#
   - ./homepage/ks.yaml
   #% endif %#
-  #% if discord_template_notifier|default({}) and discord_template_notifier.enabled|default(false) %#
+  #% if addon_discord_template_notifier.enabled %#
   - ./discord-template-notifier/ks.yaml
   #% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/kustomization.yaml.j2
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./addons/ks.yaml
-  #% if weave_gitops|default({}) and weave_gitops.enabled|default(false) %#
+  #% if addon_weave_gitops.enabled %#
   - ./weave-gitops/ks.yaml
   #% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if weave_gitops|default({}) and weave_gitops.enabled|default(false) %#
+#% if addon_weave_gitops.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -31,7 +31,7 @@ spec:
     ingress:
       enabled: true
       className: internal
-      #% if homepage|default({}) and homepage.enabled|default(false) %#
+      #% if addon_homepage.enabled %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/group: Home

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if weave_gitops|default({}) and weave_gitops.enabled|default(false) %#
+#% if addon_weave_gitops.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-#% if weave_gitops|default({}) and weave_gitops.enabled|default(false) %#
+#% if addon_weave_gitops.enabled %#
 ---
 apiVersion: v1
 kind: Secret
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
   username: admin
-  password: "#{ weave_gitops.password | encrypt }#"
+  password: "#{ addon_weave_gitops.password | encrypt }#"
 #% endif %#

--- a/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/flux-system/weave-gitops/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if weave_gitops|default({}) and weave_gitops.enabled|default(false) %#
+#% if addon_weave_gitops.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/longhorn-system/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/longhorn-system/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+#% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+#% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+#% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/app/snapshot.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/app/snapshot.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+#% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/longhorn-system/longhorn/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+#% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/longhorn-system/namespace.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/longhorn-system/namespace.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+#% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
 ---
 apiVersion: v1
 kind: Namespace

--- a/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
@@ -70,7 +70,7 @@ spec:
         className: external
         annotations:
           external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
-          #% if homepage|default({}) and homepage.enabled|default(false) %#
+          #% if addon_homepage.enabled %#
           gethomepage.dev/enabled: "true"
           gethomepage.dev/group: Network
           gethomepage.dev/name: Echo Server

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if grafana|default({}) and grafana.enabled|default(false) %#
+#% if addon_grafana.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -159,7 +159,7 @@ spec:
     ingress:
       enabled: true
       ingressClassName: internal
-      #% if homepage|default({}) and homepage.enabled|default(false) %#
+      #% if addon_homepage.enabled %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/icon: grafana.png

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if grafana|default({}) and grafana.enabled|default(false) %#
+#% if addon_grafana.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/app/secret.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/app/secret.sops.yaml.j2
@@ -1,4 +1,4 @@
-#% if grafana|default({}) and grafana.enabled|default(false) %#
+#% if addon_grafana.enabled %#
 ---
 apiVersion: v1
 kind: Secret

--- a/bootstrap/templates/kubernetes/apps/observability/grafana/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/grafana/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if grafana|default({}) and grafana.enabled|default(false) %#
+#% if addon_grafana.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if kube_prometheus_stack|default({}) and kube_prometheus_stack.enabled|default(false) %#
+#% if addon_kube_prometheus_stack.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -121,7 +121,7 @@ spec:
       ingress:
         enabled: true
         ingressClassName: internal
-        #% if homepage|default({}) and homepage.enabled|default(false) %#
+        #% if addon_homepage.enabled %#
         annotations:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/icon: prometheus.png

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if kube_prometheus_stack|default({}) and kube_prometheus_stack.enabled|default(false) %#
+#% if addon_kube_prometheus_stack.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if kube_prometheus_stack|default({}) and kube_prometheus_stack.enabled|default(false) %#
+#% if addon_kube_prometheus_stack.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if kubernetes_dashboard|default({}) and kubernetes_dashboard.enabled|default(false) %#
+#% if addon_kubernetes_dashboard.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -31,7 +31,7 @@ spec:
     ingress:
       enabled: true
       className: internal
-      #% if homepage|default({}) and homepage.enabled|default(false) %#
+      #% if addon_homepage.enabled %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/icon: kubernetes-dashboard.png

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if kubernetes_dashboard|default({}) and kubernetes_dashboard.enabled|default(false) %#
+#% if addon_kubernetes_dashboard.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/rbac.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/app/rbac.yaml.j2
@@ -1,4 +1,4 @@
-#% if kubernetes_dashboard|default({}) and kubernetes_dashboard.enabled|default(false) %#
+#% if addon_kubernetes_dashboard.enabled %#
 # For dashboard sign in token:
 # kubectl -n observability get secret kubernetes-dashboard -o jsonpath='{.data.token}' | base64 -d
 ---

--- a/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kubernetes-dashboard/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if kubernetes_dashboard|default({}) and kubernetes_dashboard.enabled|default(false) %#
+#% if addon_kubernetes_dashboard.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/observability/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/observability/kustomization.yaml.j2
@@ -3,12 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  #% if grafana|default({}) and grafana.enabled|default(false) %#
+  #% if addon_grafana.enabled %#
   - ./grafana/ks.yaml
   #% endif %#
-  #% if kube_prometheus_stack|default({}) and kube_prometheus_stack.enabled|default(false) %#
+  #% if addon_kube_prometheus_stack.enabled %#
   - ./kube-prometheus-stack/ks.yaml
   #% endif %#
-  #% if kubernetes_dashboard|default({}) and kubernetes_dashboard.enabled|default(false) %#
+  #% if addon_kubernetes_dashboard.enabled %#
   - ./kubernetes-dashboard/ks.yaml
   #% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if csi_driver_nfs|default({}) and csi_driver_nfs.enabled|default(false) %#
+#% if addon_csi_driver_nfs.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if csi_driver_nfs|default({}) and csi_driver_nfs.enabled|default(false) %#
+#% if addon_csi_driver_nfs.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/storageclass.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/app/storageclass.yaml.j2
@@ -1,5 +1,5 @@
-#% if csi_driver_nfs|default({}) and csi_driver_nfs.enabled|default(false) %#
-#% for item in csi_driver_nfs.storage_class %#
+#% if addon_csi_driver_nfs.enabled %#
+#% for item in addon_csi_driver_nfs.storage_class %#
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-nfs/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if csi_driver_nfs|default({}) and csi_driver_nfs.enabled|default(false) %#
+#% if addon_csi_driver_nfs.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if csi_driver_smb|default({}) and csi_driver_smb.enabled|default(false) %#
+#% if addon_csi_driver_smb.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if csi_driver_smb|default({}) and csi_driver_smb.enabled|default(false) %#
+#% if addon_csi_driver_smb.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/secrets.sops.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/secrets.sops.yaml.j2
@@ -1,5 +1,5 @@
-#% if csi_driver_smb|default({}) and csi_driver_smb.enabled|default(false) %#
-#% for item in csi_driver_smb.storage_class %#
+#% if addon_csi_driver_smb.enabled %#
+#% for item in addon_csi_driver_smb.storage_class %#
 #% if not item.existing_secret_name %#
 ---
 apiVersion: v1

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/storageclass.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/app/storageclass.yaml.j2
@@ -1,5 +1,5 @@
-#% if csi_driver_smb|default({}) and csi_driver_smb.enabled|default(false) %#
-#% for item in csi_driver_smb.storage_class %#
+#% if addon_csi_driver_smb.enabled %#
+#% for item in addon_csi_driver_smb.storage_class %#
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -25,6 +25,6 @@ mountOptions:
   - noperm
   - mfsymlinks
   - cache=strict
-  - noserverino  # required to prevent data corruption
+  - noserverino # required to prevent data corruption
 #% endfor %#
 #% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/csi-driver-smb/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if csi_driver_smb|default({}) and csi_driver_smb.enabled|default(false) %#
+#% if addon_csi_driver_smb.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/storage/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/kustomization.yaml.j2
@@ -3,14 +3,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  #% if csi_driver_nfs|default({}) and csi_driver_nfs.enabled|default(false) %#
+  #% if addon_csi_driver_nfs.enabled %#
   - ./csi-driver-nfs/ks.yaml
   #% endif %#
-  #% if csi_driver_smb|default({}) and csi_driver_smb.enabled|default(false) %#
+  #% if addon_csi_driver_smb.enabled %#
   - ./csi-driver-smb/ks.yaml
   #% endif %#
   - ./openebs/ks.yaml
-  #% if volsync|default({}) and volsync.enabled|default(false) %#
+  #% if addon_volsync.enabled %#
   - ./volsync/ks.yaml
   #% endif %#
 

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if volsync|default({}) and volsync.enabled|default(false) %#
+#% if addon_volsync.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if volsync|default({}) and volsync.enabled|default(false) %#
+#% if addon_volsync.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/app/prometheusrule.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/app/prometheusrule.yaml.j2
@@ -1,4 +1,4 @@
-#% if volsync|default({}) and volsync.enabled|default(false) %#
+#% if addon_volsync.enabled %#
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if volsync|default({}) and volsync.enabled|default(false) %#
+#% if addon_volsync.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -10,7 +10,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  #% if longhorn|default({}) and longhorn.enabled|default(false) %#
+  #% if addon_longhorn.enabled %#
   dependsOn:
     - name: longhorn
   #% endif %#

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if volsync|default({}) and volsync.enabled|default(false) %#
+#% if addon_volsync.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -27,7 +27,7 @@ spec:
     keepHistory: false
   values:
     controller:
-      #% if bootstrap_distribution in ['k0s', 'k3s'] and longhorn|default({}) and longhorn.enabled|default(false) %#
+      #% if bootstrap_distribution in ['k0s', 'k3s'] and addon_longhorn.enabled %#
       volumeSnapshotClasses:
         - name: longhorn-snapclass
           annotations:

--- a/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/storage/volsync/snapshot-controller/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if volsync|default({}) and volsync.enabled|default(false) %#
+#% if addon_volsync.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/tools/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/kustomization.yaml.j2
@@ -5,6 +5,6 @@ resources:
   - ./namespace.yaml
   - ./descheduler/ks.yaml
   - ./reloader/ks.yaml
-  #% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+  #% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
   - ./system-upgrade-controller/ks.yaml
   #% endif %#

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/rbac.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/app/rbac.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/agent.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/agent.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/server.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/tools/system-upgrade-controller/plans/server.yaml.j2
@@ -1,4 +1,4 @@
-#% if bootstrap_distribution == "k3s" and system_upgrade_controller|default({}) and system_upgrade_controller.enabled|default(false) %#
+#% if bootstrap_distribution == "k3s" and addon_system_upgrade_controller.enabled %#
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan

--- a/bootstrap/templates/kubernetes/k0s/k0sctl.yaml.j2
+++ b/bootstrap/templates/kubernetes/k0s/k0sctl.yaml.j2
@@ -37,7 +37,7 @@ spec:
           before:
             - sudo bash /home/#{ item.username }#/k0s/hooks/apply-system.sh
             - sudo mv /home/#{ item.username }#/k0s/containerd/unprivileged-ports.toml /etc/k0s/containerd.d/unprivileged-ports.toml
-            #% if spegel.enabled %#
+            #% if addon_spegel.enabled %#
             - sudo mv /home/#{ item.username }#/k0s/containerd/spegel.toml /etc/k0s/containerd.d/spegel.toml
             #% endif %#
         reset:

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -77,7 +77,7 @@ controlPlane:
               [plugins."io.containerd.grpc.v1.cri"]
                 enable_unprivileged_ports = true
                 enable_unprivileged_icmp = true
-              #% if spegel.enabled %#
+              #% if addon_spegel.enabled %#
               [plugins."io.containerd.grpc.v1.cri".containerd]
                 discard_unpacked_layers = false
               [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -44,7 +44,7 @@ hubble:
     ingress:
       enabled: true
       className: internal
-      #% if homepage|default({}) and homepage.enabled|default(false) %#
+      #% if addon_homepage.enabled %#
       annotations:
         gethomepage.dev/enabled: "true"
         gethomepage.dev/group: Network

--- a/bootstrap/vars/addons.sample.yaml
+++ b/bootstrap/vars/addons.sample.yaml
@@ -4,31 +4,31 @@
 #
 
 # https://gethomepage.dev
-homepage:
+addon_homepage:
   enabled: false
 
 # https://github.com/grafana/grafana
-grafana:
+addon_grafana:
   enabled: false
   # password: # password for `admin` user
 
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
-kube_prometheus_stack:
+addon_kube_prometheus_stack:
   enabled: false
 
 # https://github.com/kubernetes/dashboard
-kubernetes_dashboard:
+addon_kubernetes_dashboard:
   enabled: false
   # Password can be obtained by running the following command once it is deployed:
   # kubectl -n monitoring get secret kubernetes-dashboard -o jsonpath='{.data.token}' | base64 -d
 
 # https://github.com/weaveworks/weave-gitops
-weave_gitops:
+addon_weave_gitops:
   enabled: false
   # password: # password for `admin` user
 
 # https://github.com/kubernetes-csi/csi-driver-nfs
-csi_driver_nfs:
+addon_csi_driver_nfs:
   enabled: false
   storage_class:
     # - name:   # name of the storage class (must match [a-z0-9-]+)
@@ -37,7 +37,7 @@ csi_driver_nfs:
     # ...
 
 # https://github.com/kubernetes-csi/csi-driver-smb
-csi_driver_smb:
+addon_csi_driver_smb:
   enabled: false
   storage_class:
     # - name:      # name of the storage class (must match [a-z0-9-]+)
@@ -53,7 +53,7 @@ csi_driver_smb:
     # ...
 
 # https://github.com/rancher/system-upgrade-controller
-system_upgrade_controller:
+addon_system_upgrade_controller:
   # IMPORTANT: Only enable this if you also track the version of k3s in the
   # ansible configuration files. Running ansible against an already provisioned
   # cluster with this enabled might cause your cluster to be downgraded.
@@ -61,23 +61,23 @@ system_upgrade_controller:
   enabled: false
 
 # https://github.com/morphy2k/rss-forwarder
-discord_template_notifier:
+addon_discord_template_notifier:
   # Will post commits from the template repository to the specified discord channel
   # so it's easier to keep track of changes.
   enabled: false
   webhook_url: # Discord webhook url
 
 # https://github.com/backube/volsync
-volsync:
+addon_volsync:
   enabled: false
 
 # https://github.com/XenitAB/spegel
-spegel:
+addon_spegel:
   # Note: This only applies to k0s at the moment
   enabled: false
 
 # https://github.com/longhorn/longhorn
-longhorn:
+addon_longhorn:
   # IMPORTANT: Only enable this if you have 3 or more nodes in your cluster
   # and you have enough IOPS on disk to support the number of replicas.
   # Longhorn is currently unsupported in Talos


### PR DESCRIPTION
All these changes makes the templates easier to read when looking at the logic.

- No more need to use defaults in jinja logic
- Rename addons vars to add a `addon_` prefix