### PR TITLE
Update addons.sample.yaml with correct namespace for kubernetes-dashboard

### DIFF
--- a/bootstrap/vars/addons.sample.yaml
+++ b/bootstrap/vars/addons.sample.yaml
@@ -20,7 +20,7 @@ addon_kube_prometheus_stack:
 addon_kubernetes_dashboard:
   enabled: false
   # NOTE: Password can be obtained by running the following command once it is deployed:
-  #   kubectl -n monitoring get secret kubernetes-dashboard -o jsonpath='{.data.token}' | base64 -d
+  #   kubectl -n observability get secret kubernetes-dashboard -o jsonpath='{.data.token}' | base64 -d
 
 # https://github.com/weaveworks/weave-gitops
 addon_weave_gitops:


### PR DESCRIPTION
Looks like this comment was missed when the `monitoring` namespace was changed to `observability` in 
https://github.com/onedr0p/flux-cluster-template/pull/1110.