### PR TITLE
fixes: lychee pipeline workflow

### DIFF
--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -18,6 +18,9 @@ jobs:
     name: Lychee
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Scan for broken links
         uses: lycheeverse/lychee-action@v1
         id: lychee


### PR DESCRIPTION
Currently lychee workflow is failing on missing .git directory. This PR adds checkout action to the workflow to fix the issue. 